### PR TITLE
[canonicalise-hashes] Canonicalise hashes before comparing them

### DIFF
--- a/src/main/scala/net/ripe/rpki/publicationserver/StateActor.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/StateActor.scala
@@ -89,7 +89,7 @@ class StateActor(conf: AppConfig) extends Actor with Hashing with Logging {
   private def applyDelete(state: State, uri: URI, strHash: String): Either[ReportError, State] = {
     state.get(uri) match {
       case Some((base64, Hash(h), _)) =>
-        if (h == strHash)
+        if (h.toUpperCase == strHash.toUpperCase)
           Right(state - uri)
         else {
           Left(ReportError(BaseError.NonMatchingHash, Some(s"Cannot withdraw the object [$uri], hash doesn't match.")))
@@ -102,7 +102,7 @@ class StateActor(conf: AppConfig) extends Actor with Hashing with Logging {
   private def applyReplace(state: State, clientId: ClientId, uri: URI, strHash: String, base64: Base64): Either[ReportError, State] = {
     state.get(uri) match {
       case Some((_, Hash(h), _)) =>
-        if (h == strHash)
+        if (h.toUpperCase == strHash.toUpperCase)
           Right(state + (uri ->(base64, hash(base64), clientId)))
         else
           Left(ReportError(BaseError.NonMatchingHash, Some(s"Cannot republish the object [$uri], hash doesn't match")))

--- a/src/test/resources/publishWithHashXmlResponse.xml
+++ b/src/test/resources/publishWithHashXmlResponse.xml
@@ -1,0 +1,7 @@
+<msg
+    type="reply"
+    version="3"
+    xmlns="http://www.hactrn.net/uris/rpki/publication-spec/">
+  <publish
+      uri="rsync://wombat.example/Alice/blCrcCp9ltyPDNzYKPfxc.cer"/>
+</msg>


### PR DESCRIPTION
The replace and withdraw operations involve server-side hash
comparisons, so as to establish agreement between the client and the
server about the files that will be affected.  On the server side, the
hashes are generated with uppercase characters (see the Hashing
trait), but the client's hash is used unchanged, which means that the
client must also send hashes with uppercase characters for these
operations to be successful.  The relevant specification (RFC 8181)
does not mandate uppercase or lowercase characters in the hash, so
the hashes are now canonicalised before they are compared.  The
current behaviour causes problems for the rpki.net publication client,
which in at least some instances will send hashes that contain
lowercase characters.