### PR TITLE
Delete oldest sessions on the start right away, don't wait for an hour.

### DIFF
--- a/src/main/scala/net/ripe/rpki/publicationserver/messaging/Messages.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/messaging/Messages.scala
@@ -22,5 +22,7 @@ object Messages {
   case class CleanUpDeltas(sessionId: UUID, serials: Iterable[Long])
 
   case class CleanUpRepo(sessionId: UUID)
+
+  case class CleanUpRepoOldOnesNow(timestamp: FileTime, sessionId: UUID)
 }
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/messaging/RrdpFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/messaging/RrdpFlusher.scala
@@ -2,6 +2,7 @@ package net.ripe.rpki.publicationserver.messaging
 
 import java.nio.file.attribute.FileTime
 import java.time.Instant
+import java.time.temporal.{ChronoUnit, TemporalUnit}
 import java.util.{Date, UUID}
 
 import akka.actor.{Actor, Props}
@@ -55,7 +56,8 @@ class RrdpFlusher(conf: AppConfig) extends Actor with Logging {
 
 
   def scheduleRrdpRepositoryCleanup() = {
-    rrdpCleaner ! CleanUpRepoOldOnesNow(FileTime.from(Instant.now()), sessionId)
+    val oldEnough = FileTime.from(Instant.now().minus(conf.unpublishedFileRetainPeriod.toSeconds, ChronoUnit.SECONDS))
+    rrdpCleaner ! CleanUpRepoOldOnesNow(oldEnough, sessionId)
     scheduleCleanup(CleanUpRepo(sessionId))
   }
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/messaging/RrdpFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/messaging/RrdpFlusher.scala
@@ -149,7 +149,7 @@ class RrdpCleaner(conf: AppConfig) extends Actor with Logging {
       rrdpWriter.deleteDeltas(conf.rrdpRepositoryPath, sessionId, serials)
     case CleanUpRepo(sessionId) =>
       logger.info(s"Removing all the sessions in RRDP repository except for $sessionId")
-      rrdpWriter.cleanRepositoryExceptOneSession(conf.rrdpRepositoryPath, sessionId)
+      rrdpWriter.cleanRepositoryExceptOneSessionOlderThan(conf.rrdpRepositoryPath, FileTime.from(Instant.now()), sessionId)
     case CleanUpRepoOldOnesNow(timestamp, sessionId) =>
       logger.info(s"Removing all the older sessions in RRDP repository except for $sessionId")
       rrdpWriter.cleanRepositoryExceptOneSessionOlderThan(conf.rrdpRepositoryPath, timestamp, sessionId)

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RemovingFileVisitor.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RemovingFileVisitor.scala
@@ -47,6 +47,7 @@ class RemoveAllVisitorExceptOneSession(sessionId: String, timestamp: Option[File
       FileVisitResult.SKIP_SUBTREE
     else {
       if (deleteIt(file)) {
+        logger.info(s"Removing file $file")
         Files.deleteIfExists(file)
       }
       FileVisitResult.CONTINUE
@@ -58,6 +59,7 @@ class RemoveAllVisitorExceptOneSession(sessionId: String, timestamp: Option[File
       FileVisitResult.SKIP_SUBTREE
     else {
       if (FSUtil.isEmptyDir(dir)) {
+        logger.info(s"Removing directory $dir")
         Files.deleteIfExists(dir)
       }
       FileVisitResult.CONTINUE

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RemovingFileVisitor.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RemovingFileVisitor.scala
@@ -35,13 +35,13 @@ class RemovingFileVisitor(timestamp: FileTime, filenameToDelete: Path, latestSer
 }
 
 class RemoveAllVisitorExceptOneSession(sessionId: String, timestamp: FileTime) extends SimpleFileVisitor[Path] with Logging {
-  def deleteIt(path: Path): Boolean = FSUtil.isModifiedBefore(path, timestamp)
+  def oldEnough(path: Path): Boolean = FSUtil.isModifiedBefore(path, timestamp)
 
   override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
     if (file.toString.contains(sessionId) || file.toString.endsWith(Rrdp.notificationFilename))
       FileVisitResult.SKIP_SUBTREE
     else {
-      if (deleteIt(file)) {
+      if (oldEnough(file)) {
         logger.info(s"Removing file $file")
         Files.deleteIfExists(file)
       }

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RemovingFileVisitor.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RemovingFileVisitor.scala
@@ -34,13 +34,8 @@ class RemovingFileVisitor(timestamp: FileTime, filenameToDelete: Path, latestSer
 
 }
 
-class RemoveAllVisitorExceptOneSession(sessionId: String, timestamp: Option[FileTime]) extends SimpleFileVisitor[Path] with Logging {
-  def deleteIt(path: Path): Boolean = {
-    timestamp match {
-      case None => true
-      case Some(t) => FSUtil.isModifiedBefore(path, t)
-    }
-  }
+class RemoveAllVisitorExceptOneSession(sessionId: String, timestamp: FileTime) extends SimpleFileVisitor[Path] with Logging {
+  def deleteIt(path: Path): Boolean = FSUtil.isModifiedBefore(path, timestamp)
 
   override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
     if (file.toString.contains(sessionId) || file.toString.endsWith(Rrdp.notificationFilename))

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RrdpRepositoryWriter.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RrdpRepositoryWriter.scala
@@ -17,12 +17,8 @@ class RrdpRepositoryWriter extends Logging {
     getStateDir(rootDir, sessionId.toString, serial)
   }
 
-  def cleanRepositoryExceptOneSession(rootDir: String, sessionId: UUID): Path = {
-    Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString, None))
-  }
-
   def cleanRepositoryExceptOneSessionOlderThan(rootDir: String, timestamp: FileTime, sessionId: UUID): Path = {
-    Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString, Some(timestamp)))
+    Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString, timestamp))
   }
 
   private val fileAttributes = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"))

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RrdpRepositoryWriter.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/fs/RrdpRepositoryWriter.scala
@@ -18,7 +18,11 @@ class RrdpRepositoryWriter extends Logging {
   }
 
   def cleanRepositoryExceptOneSession(rootDir: String, sessionId: UUID): Path = {
-    Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString))
+    Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString, None))
+  }
+
+  def cleanRepositoryExceptOneSessionOlderThan(rootDir: String, timestamp: FileTime, sessionId: UUID): Path = {
+    Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString, Some(timestamp)))
   }
 
   private val fileAttributes = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"))


### PR DESCRIPTION
We have removal of previous sessions, but currently it is scheduled in an hour from the start. Remove them right away if the files are older than an hour.