### PR TITLE
Delete temp directories

### DIFF
--- a/src/main/scala/net/ripe/rpki/publicationserver/Hashing.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Hashing.scala
@@ -10,17 +10,28 @@ trait Hashing {
 
   private val base64 = BaseEncoding.base64()
 
-  def stringify(bytes: Array[Byte]) : String = Option(bytes).map {
-    _.map { b => String.format("%02X", new Integer(b & 0xff)) }.mkString
-  }.getOrElse("")
+  def stringify(bytes: Array[Byte]): String = Option(bytes).map(bytesToHex).getOrElse("")
 
-  def stringify(hash: Hash) : String = Option(hash).map { h =>
-    stringify(h.hash.getBytes("UTF-8"))
-  }.getOrElse("")
+  private val HEX_ARRAY = "0123456789ABCDEF".toCharArray
+
+  // Copy-pasted from here
+  // https://stackoverflow.com/questions/9655181/how-to-convert-a-byte-array-to-a-hex-string-in-java
+  // as the fastest way to do it
+  def bytesToHex(bytes: Array[Byte]): String = {
+    val hexChars = new Array[Char](bytes.length * 2)
+    var j = 0
+    while (j < bytes.length) {
+      val v = bytes(j) & 0xFF
+      hexChars(j * 2) = HEX_ARRAY(v >>> 4)
+      hexChars(j * 2 + 1) = HEX_ARRAY(v & 0x0F)
+      j += 1
+    }
+    new String(hexChars)
+  }
 
   def hash(bytes: Array[Byte]): Hash = {
-    val digest = MessageDigest.getInstance("SHA-256")
-    Hash(stringify(digest.digest(bytes)))
+    val sha256 = MessageDigest.getInstance("SHA-256")
+    Hash(stringify(sha256.digest(bytes)))
   }
 
   def hash(b64: Base64): Hash = {

--- a/src/main/scala/net/ripe/rpki/publicationserver/StateActor.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/StateActor.scala
@@ -86,9 +86,10 @@ class StateActor(conf: AppConfig) extends Actor with Hashing with Logging {
   private def applyDelete(state: State, uri: URI, hashToReplace: String): Either[ReportError, State] = {
     state.get(uri) match {
       case Some((_, Hash(foundHash), _)) =>
-        if (foundHash.toUpperCase == hashToReplace.toUpperCase)
+        if (foundHash.toUpperCase == hashToReplace.toUpperCase) {
+          logger.debug(s"Deleting $uri with hash ${foundHash.toUpperCase}")
           Right(state - uri)
-        else {
+        } else {
           Left(ReportError(BaseError.NonMatchingHash,
             Some(s"Cannot withdraw the object [$uri], hash doesn't match, passed ${hashToReplace.toUpperCase}, but existing one is ${foundHash.toUpperCase}.")))
         }
@@ -100,9 +101,11 @@ class StateActor(conf: AppConfig) extends Actor with Hashing with Logging {
   private def applyReplace(state: State, clientId: ClientId, uri: URI, hashToReplace: String, base64: Base64): Either[ReportError, State] = {
     state.get(uri) match {
       case Some((_, Hash(foundHash), _)) =>
-        if (foundHash.toUpperCase == hashToReplace.toUpperCase)
-          Right(state + (uri -> (base64, hash(base64), clientId)))
-        else
+        if (foundHash.toUpperCase == hashToReplace.toUpperCase) {
+          val newHash = hash(base64)
+          logger.debug(s"Replacing $uri with hash $foundHash -> $newHash")
+          Right(state + (uri -> (base64, newHash, clientId)))
+        } else
           Left(ReportError(BaseError.NonMatchingHash,
             Some(s"Cannot republish the object [$uri], hash doesn't match, passed ${hashToReplace.toUpperCase}, but existing one is ${foundHash.toUpperCase}.")))
       case None =>
@@ -114,7 +117,9 @@ class StateActor(conf: AppConfig) extends Actor with Hashing with Logging {
     if (state.contains(uri)) {
       Left(ReportError(BaseError.HashForInsert, Some(s"Tried to insert existing object [$uri].")))
     } else {
-      Right(state + (uri -> (base64, hash(base64), clientId)))
+      val newHash = hash(base64)
+      logger.debug(s"Adding $uri with hash $newHash")
+      Right(state + (uri -> (base64, newHash, clientId)))
     }
   }
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/messaging/RsyncFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/messaging/RsyncFlusher.scala
@@ -24,6 +24,7 @@ class RsyncFlusher(conf: AppConfig) extends Actor with Logging {
   }
 
   private def initRsyncRepo(state: State) = Try {
+    rsyncWriter.cleanUpTemporaryDirs()
     rsyncWriter.writeSnapshot(state)
   } recover {
     case e: Exception =>
@@ -32,7 +33,7 @@ class RsyncFlusher(conf: AppConfig) extends Actor with Logging {
       throw new ThreadDeath
   }
 
-  private def updateRsyncRepo(message: QueryMessage) = {
+  private def updateRsyncRepo(message: QueryMessage): Unit = {
     logger.debug(s"Writing message to rsync repo:\n$message")
     rsyncWriter.updateRepo(message)
   }

--- a/src/main/scala/net/ripe/rpki/publicationserver/model/Delta.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/model/Delta.scala
@@ -3,30 +3,30 @@ package net.ripe.rpki.publicationserver.model
 import java.io.ByteArrayOutputStream
 import java.util.{Date, UUID}
 
-import net.ripe.rpki.publicationserver.{Hashing, PublishQ, QueryPdu, WithdrawQ}
+import net.ripe.rpki.publicationserver.{Hash, Hashing, PublishQ, QueryPdu, WithdrawQ}
 
 case class Delta(sessionId: UUID, serial: Long, pdus: Seq[QueryPdu], whenToDelete: Option[Date] = None) extends Hashing {
 
-  lazy val bytes = serialize
-  lazy val contentHash = hash(bytes)
-  lazy val binarySize = bytes.length
+  lazy val bytes: Array[Byte] = serialize
+  lazy val contentHash: Hash = hash(bytes)
+  lazy val binarySize: Int = bytes.length
 
-  def markForDeletion(d: Date) = copy(whenToDelete = Some(d))
+  def markForDeletion(d: Date): Delta = copy(whenToDelete = Some(d))
 
-  private def serialize = {
+  private def serialize: Array[Byte] = {
     val stream = new ByteArrayOutputStream()
-    Dump.streamChars(s"""<delta version="1" session_id="$sessionId" serial="$serial" xmlns="http://www.ripe.net/rpki/rrdp">""", stream)
+    Dump.streamChars(s"""<delta version="1" session_id="$sessionId" serial="$serial" xmlns="http://www.ripe.net/rpki/rrdp">\n""", stream)
     pdus.foreach {
       case PublishQ(uri, _, None, base64) =>
         Dump.streamChars(s"""<publish uri="$uri">""", stream)
         Dump.streamChars(base64.value, stream)
-        Dump.streamChars("</publish>", stream)
+        Dump.streamChars("</publish>\n", stream)
       case PublishQ(uri, _, Some(hash), base64) =>
         Dump.streamChars(s"""<publish uri="$uri" hash="$hash">""", stream)
         Dump.streamChars(base64.value, stream)
-        Dump.streamChars("</publish>", stream)
+        Dump.streamChars("</publish>\n", stream)
       case WithdrawQ(uri, _, hash) =>
-        Dump.streamChars(s"""<withdraw uri="$uri" hash="$hash"/>""", stream)
+        Dump.streamChars(s"""<withdraw uri="$uri" hash="$hash"/>\n""", stream)
     }
     Dump.streamChars("</delta>", stream)
     stream.toByteArray

--- a/src/main/scala/net/ripe/rpki/publicationserver/model/Dump.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/model/Dump.scala
@@ -3,7 +3,6 @@ package net.ripe.rpki.publicationserver.model
 import java.io.ByteArrayOutputStream
 
 object Dump {
-  def streamChars(s: String, stream: ByteArrayOutputStream): Unit = {
+  def streamChars(s: String, stream: ByteArrayOutputStream): Unit =
     stream.write(s.getBytes("US-ASCII"))
-  }
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/model/Snapshot.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/model/Snapshot.scala
@@ -14,12 +14,12 @@ case class Snapshot(serverState: ServerState, pdus: Seq[(Base64, URI)]) extends 
   private[model] def serialize = {
     val ServerState(sessionId, serial) = serverState
     val stream = new ByteArrayOutputStream()
-    Dump.streamChars(s"""<snapshot version="1" session_id="$sessionId" serial="$serial" xmlns="http://www.ripe.net/rpki/rrdp">""", stream)
+    Dump.streamChars(s"""<snapshot version="1" session_id="$sessionId" serial="$serial" xmlns="http://www.ripe.net/rpki/rrdp">\n""", stream)
     pdus.foreach { pdu =>
       val (base64, uri) = pdu
       Dump.streamChars(s"""<publish uri="$uri">""", stream)
       Dump.streamChars(base64.value, stream)
-      Dump.streamChars("</publish>", stream)
+      Dump.streamChars("</publish>\n", stream)
     }
     Dump.streamChars("</snapshot>", stream)
     stream.toByteArray

--- a/src/test/scala/net/ripe/rpki/publicationserver/HashingTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HashingTest.scala
@@ -1,0 +1,11 @@
+package net.ripe.rpki.publicationserver
+
+import org.scalatest.{FunSuite, Matchers}
+
+class HashingTest extends FunSuite with Matchers with Hashing {
+  test("should parse publish message") {
+    stringify(null) should be("")
+    stringify(Array()) should be("")
+    stringify(Array(0x11, 0x22, 0x00, 0xAB, 0xFF).map(_.toByte)) should be("112200ABFF")
+  }
+}

--- a/src/test/scala/net/ripe/rpki/publicationserver/model/DeltaTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/model/DeltaTest.scala
@@ -14,10 +14,10 @@ class DeltaTest extends PublicationServerBaseTest {
     val withdrawQ = WithdrawQ(new URI("rsync://bla.delete"), None, "AABB")
     val state = Delta(sessionId, 123L, Seq(publishQ1, withdrawQ, publishQ2), None)
 
-    val xml = "<delta version=\"1\" session_id=\"" + sessionId + "\" serial=\"123\" xmlns=\"http://www.ripe.net/rpki/rrdp\">" +
-      "<publish uri=\"rsync://bla.replace\" hash=\"AABBCCEE\">321</publish>" +
-      "<withdraw uri=\"rsync://bla.delete\" hash=\"AABB=\"/>" +
-      "<publish uri=\"rsync://bla.add\">765432319</publish>" +
+    val xml = "<delta version=\"1\" session_id=\"" + sessionId + "\" serial=\"123\" xmlns=\"http://www.ripe.net/rpki/rrdp\">\n" +
+      "<publish uri=\"rsync://bla.replace\" hash=\"AABBCCEE\">321</publish>\n" +
+      "<withdraw uri=\"rsync://bla.delete\" hash=\"AABB\"/>\n" +
+      "<publish uri=\"rsync://bla.add\">765432319</publish>\n" +
       "</delta>"
     state.bytes should be(toBytes(xml))
   }

--- a/src/test/scala/net/ripe/rpki/publicationserver/model/SnapshotTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/model/SnapshotTest.scala
@@ -11,7 +11,7 @@ class SnapshotTest extends PublicationServerBaseTest {
     val state = Snapshot(ServerState(sessionId, 123L), Seq((Base64("321"), new URI("rsync://bla"))))
 
     state.bytes should be(toBytes(
-      s"""<snapshot version="1" session_id="$sessionId" serial="123" xmlns="http://www.ripe.net/rpki/rrdp"><publish uri="rsync://bla">321</publish></snapshot>"""))
+      s"""<snapshot version="1" session_id="$sessionId" serial="123" xmlns="http://www.ripe.net/rpki/rrdp">\n<publish uri="rsync://bla">321</publish>\n</snapshot>"""))
   }
 
   private def toBytes(s: String) = {


### PR DESCRIPTION
This is to remove "temp-" files on the start, as sometimes they can stay there in the "working" directory and eat up all the inodes.

Also, ooopsie but there's some more changes that were supposed to be in a separate PR, such as changes in PublicationMessages.scala.