### PR TITLE
Do not crash with error 500 when Base64 in an object is malformed.

### DIFF
--- a/src/main/scala/net/ripe/rpki/publicationserver/PublicationMessages.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/PublicationMessages.scala
@@ -16,6 +16,7 @@ object BaseError extends Enumeration {
   val NonMatchingHash = Value
   val CouldNotPersist = Value
   val InvalidBase64 = Value
+  val XmlSchemaValidationError = Value
 }
 
 case class BaseError(code: BaseError.Code, message: String)

--- a/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
@@ -84,7 +84,7 @@ class PublicationService
                 } catch {
                   case e: Exception =>
                     Future {
-                      ErrorMsg(BaseError(BaseError.XmlSchemaValidationError, s"XML parsing/validation error: " + e.getMessage))
+                      ErrorMsg(BaseError(BaseError.XmlSchemaValidationError, s"XML parsing/validation error: ${e.getMessage}"))
                     }
                 }
               }
@@ -121,5 +121,4 @@ class PublicationService
     }
   }
 }
-
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
@@ -20,7 +20,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.io.{BufferedSource, Source}
 import scala.util.{Failure, Success, Try}
 import akka.util.ByteString
-import com.ctc.wstx.exc.WstxValidationException
 
 object PublicationService {
     val MediaTypeString = "application/rpki-publication"

--- a/src/test/resources/publishBrokenBase64.xml
+++ b/src/test/resources/publishBrokenBase64.xml
@@ -1,0 +1,9 @@
+<msg
+    type="query"
+    version="3"
+    xmlns="http://www.hactrn.net/uris/rpki/publication-spec/">
+  <publish
+      uri="rsync://wombat.example/Alice/blCrcCp9ltyPDNzYKPfxc.cer">
+    BROKENBASE^$
+  </publish>
+</msg>

--- a/src/test/scala/net/ripe/rpki/publicationserver/PublicationServiceTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/PublicationServiceTest.scala
@@ -12,7 +12,7 @@ object Store {
   val objectStore = ObjectStore.get
 }
 
-class PublicationServiceTest extends PublicationServerBaseTest with Hashing with BeforeAndAfterAll{
+class PublicationServiceTest extends PublicationServerBaseTest with Hashing with BeforeAndAfterAll {
 
   val theRsyncWriter = mock[RsyncRepositoryWriter]
   val conf = new AppConfig
@@ -219,6 +219,15 @@ class PublicationServiceTest extends PublicationServerBaseTest with Hashing with
   test("should leave POST requests to other paths unhandled") {
     Post("/kermit") ~> publicationService.publicationRoutes ~> check {
       handled should be(false)
+    }
+  }
+
+  test("should return <error ...> is base64 is invalid") {
+    val service = publicationService
+    POST("/?clientId=1234", getFile("/publishBrokenBase64.xml").mkString) ~> service.publicationRoutes ~> check {        
+      response.status.isSuccess should be(false)
+      val responseStr = responseAs[String]
+      responseStr should include("XML parsing/validation error: \"BROKENBASE")
     }
   }
 }


### PR DESCRIPTION
Also, refactor error processing to have more sane responses.