### PR TITLE
Serial generation time in db

### DIFF
--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -52,7 +52,6 @@ CREATE TABLE versions
 CREATE UNIQUE INDEX idx_objects_hash ON objects (hash);
 CREATE UNIQUE INDEX idx_objects_url ON objects (url) WHERE NOT is_deleted;
 
--- Only one version in the pending state is allowed (it must be the last one)
 CREATE UNIQUE INDEX idx_uniq_versions_generates ON versions (session_id, serial);
 
 COMMIT;

--- a/src/main/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriter.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriter.scala
@@ -18,7 +18,7 @@ class RrdpRepositoryWriter extends Logging {
   }
 
   def cleanRepositoryExceptOneSessionOlderThan(rootDir: String, timestamp: FileTime, sessionId: UUID): Path = {
-    Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString, timestamp))
+      Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString, timestamp))
   }
 
   private val fileAttributes = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"))
@@ -49,7 +49,7 @@ class RrdpRepositoryWriter extends Logging {
 
   def cleanUpEmptyDir(rootDir: String, sessionId: UUID, serial: Long) = {
     val dir = Paths.get(rootDir, sessionId.toString, serial.toString)
-    if (FSUtil.isEmptyDir(dir)) {
+    if (dir.toFile.exists() && FSUtil.isEmptyDir(dir)) {
       Files.deleteIfExists(dir)
     }
   }

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -91,7 +91,7 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
           writeRrdpDelta(sessionId, s, deltaOs)
         }
       }
-      logger.info(s"Generated delta $sessionId, $s, took ${deltaDuration}ms")
+      logger.info(s"Generated delta, session id = $sessionId, serial = $s, took ${deltaDuration}ms")
       pgStore.updateDeltaInfo(sessionId, s, deltaHash, deltaSize)
     }
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -100,6 +100,7 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
       case Some(previous) =>
         // Catch up on deltas, i.e. generate deltas from `latestFrozenPreviously` to `serial`.
         // This is to cover the case if version freeze was initiated by some other instance
+        // and this instance is lagging behind.
         for (s <- (previous + 1) to serial) {
           writeDelta(s)
         }

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -236,16 +236,6 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
     IOStream.string("</publish>\n", stream)
   }
 
-//  def withOS(createStream: => HashingSizedStream)(f : HashingSizedStream => Unit) = {
-//    val stream = createStream
-//    try {
-//      f(stream)
-//      stream.summary
-//    } finally {
-//      stream.close()
-//    }
-//  }
-
   def withTmpStream(targetFile: Path)(f : HashingSizedStream => Unit) = {
     val tmpFile = Files.createTempFile(targetFile.getParent, "", ".xml")
     val tmpStream = new HashingSizedStream(new FileOutputStream(tmpFile.toFile))


### PR DESCRIPTION
This is to introduce the 'catch up' mechanism for deltas.

If there is more than one instance of a publication server, a situation when one of them 'freezes' the version of the DB and the others don't know about it will be common. This PR introduces correct handling of this type of situations. `updateFS` will update its RRDP/rsync repository with all serials between the last one it remembers and the one in the DB.