### PR TITLE
Remove unused config entry `locationLogfile`

### DIFF
--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -24,7 +24,6 @@ class AppConfig {
   lazy val rrdpPort = getConfig.getInt("rrdp.port")
   lazy val rrdpRepositoryPath = getConfig.getString("locations.rrdp.repository.path")
   lazy val rrdpRepositoryUri  = getConfig.getString("locations.rrdp.repository.uri")
-  lazy val locationLogfile = getConfig.getString("locations.logfile")
   lazy val unpublishedFileRetainPeriod = Duration(getConfig.getDuration("unpublished-file-retain-period", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
   lazy val snapshotSyncDelay = Duration(getConfig.getDuration("snapshot-sync-delay", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
   lazy val defaultTimeout = Duration(getConfig.getDuration("default.timeout", TimeUnit.MINUTES), TimeUnit.MINUTES)


### PR DESCRIPTION
The Config entry for `locationLogfile` is no longer used (since `d933479`) and therefore can be cleaned up.