### PR TITLE
Use distinct image names

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ build_tagged_image:
   only:
     - master@rpki/rpki-publication-server
 
-build_manual_image:
+build_branch_image:
   stage: deploy
   when: manual
   image: docker:latest
@@ -49,8 +49,10 @@ build_manual_image:
     - docker:dind
   script:
     - echo $CI_REGISTRY_PASSWORD | docker login -u $CI_REGISTRY_USER --password-stdin $CI_REGISTRY
-    - docker build --tag $CI_REGISTRY_IMAGE:dev .
-    - docker push $CI_REGISTRY_IMAGE:dev
+    - docker build --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+  except:
+    - master
 
 deploy-prepdev:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ build:
     - apk add --update curl
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
   script:
-    - docker build -f Dockerfile.artifact_container --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA .
+    - docker build -f Dockerfile.artifact_container --tag $CI_REGISTRY_IMAGE-artifacts:$CI_COMMIT_SHA .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
     - curl -X POST -F "token=$RPKI_AWS_TOKEN" -F "ref=$BRANCH_TARGET" -F "variables[DEPLOY_TARGET]=$DEPLOY_TARGET" -F "variables[IMAGE_TARGET]=$CI_COMMIT_SHA"  "$AWS_PIPELINE_TRIGGER"
 


### PR DESCRIPTION
Since one image is used for transporting pipeline artifacts from one pipeline to another, suffix that image with `-artifacts` to clearly distinguish it from the _actual_ publication server image.