### PR TITLE
Ignore some patterns in project root only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-target
+/target
+/snapshots
+/store
+/project/metals.sbt
 *.iml
 *.log*
 *.db
@@ -9,7 +12,4 @@ target
 .store
 .bloop
 .metals
-snapshots
-store
-project/metals.sbt
 .scalafmt.conf


### PR DESCRIPTION
Git ignore patterns are not simply paths from the project root. Hence a pattern
`store` will ignore _any_ file named `store` somewhere in the working
directory. Since we also have a java package `store`, it's unhelpful to ignore it.