### PR TITLE
Use `AppConfig` for test pgconfig

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,14 @@
 build:
   stage: build
   image: $CI_REGISTRY/swe/gitlab-ci/sbt:1.3-2.12-jdk-8
+  services:
+    - postgres:12.1
+  variables:
+    POSTGRES_DB: pubserver
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: postgres
   script:
-    - sbt clean test universal:packageZipTarball assembly
-
+    - sbt clean test universal:packageZipTarball assembly -Dpostgresql.url=jdbc:postgresql://postgres/${POSTGRES_DB} -Dpostgresql.user=${POSTGRES_USER} -Dpostgresql.password=${POSTGRES_PASSWORD}
   artifacts:
     paths:
       - target/universal/rpki-publication-server-1.1-SNAPSHOT.tgz

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -4,4 +4,6 @@ locations.rsync.repository-mapping = [
 //  { "rsync://nonexistent.example" : "/nonexistent" },
 ]
 
+postgresql.url = "jdbc:postgresql://localhost/pubserver_test"
+
 server.address=0.0.0.0

--- a/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
@@ -28,7 +28,7 @@ abstract class PublicationServerBaseTest extends AnyFunSuite with BeforeAndAfter
 
   var tempXodusDir: File = _
 
-  val pgTestConfig = PgConfig(url = "jdbc:postgresql://localhost:5432/pubserver_test", user = "pubserver", password = "pubserver")
+  val pgTestConfig = new AppConfig().pgConfig
 
   protected def createPgStore = {
     PgStore.migrateDB(pgTestConfig)


### PR DESCRIPTION
Using the regular `AppConfig` allows overrides through system properties, which
is convenient for CI builds.