### PR TITLE
Require TLS configuration to start publication server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-target
+/target
+/snapshots
+/store
+/project/metals.sbt
 *.iml
 *.log*
 *.db
@@ -9,9 +12,6 @@ target
 .store
 .bloop
 .metals
-snapshots
-store
-project/metals.sbt
 .scalafmt.conf
 .vscode
 .vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 .scalafmt.conf
 .vscode
 .vagrant
+project/project
+project/target

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ docker build . -t rpki-publication-server
 docker run -it \
   -p 7766:7766 \
   -p 7788:7788 \
-  -v `pwd`/ssl:/conf/ssl \
+  -v `pwd`/src/test/resources/certificates/:/conf/ssl \
   -e ENABLE_SSL=on \
   -e KEYSTORE_PATH=/conf/ssl/serverKeyStore.ks \
   -e TRUSTSTORE_PATH=/conf/ssl/serverTrustStore.ks \

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Use *bin/rpki-publication-server.sh* script to start and stop the server:
 Configuring HTTPS for publication protocol
 ------------------------------------------
 
-It is possible to use HTTPS for publication protocol, with or without client authentication.
+The publication server **requires** HTTPS for the publication protocol with client authentication. This mitigates the
+risk of publication server from being launched without HTTPS in a production setting by accident (ROS 2.15.3).
 
-To enable HTTPS for publication protocol, set publication.spray.can.server.ssl-encryption parameter to "on", and 
-define publication.server.keystore.\* properties.
+**Keep in mind** that client authentication needs to be setup both on the side of the publisher as well.
 
 To create self-signed server's certificate, use following commands:
 

--- a/docker/publication-server-docker.conf
+++ b/docker/publication-server-docker.conf
@@ -36,8 +36,8 @@ locations.rsync = {
   directory-permissions = "rwxrwxr-x"
   file-permissions = "rw-rw-r--"
   repository-mapping = [
-    {"rsync://localhost:873/ta/": "/data/rsync/ta"},
-    {"rsync://localhost:873/repository/": "/data/rsync/repository"}
+    {"rsync://localhost:10873/ta/": "/data/rsync/ta"},
+    {"rsync://localhost:10873/repository/": "/data/rsync/repository"}
   ]
 }
 

--- a/docker/publication-server-docker.conf
+++ b/docker/publication-server-docker.conf
@@ -5,10 +5,9 @@
 
 publication {
   port = 7766
-  spray.can.server.ssl-encryption = "yes"
-  spray.can.server.ssl-encryption = ${?ENABLE_SSL}
 
-  # if you use HTTPS for publication server (publication.spray.can.server.ssl-encryption == on)
+  # Set up TLS and client authentication as described in the README
+  #
   # put the certificate in a keystore and specify it's filename and password below
   # use the same password for the certificate and for the keystore
   server.keystore.location = ""

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,6 +10,9 @@ publication {
   # and specify it's filename and password here
   server.truststore.location = ""
   server.truststore.password = ""
+
+  # Maximum entity size, only applied to endpoints where needed, preferibly behind client tls
+  max-entity-size = 512M
 }
 
 server.address="::0"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 publication {
   port = 7766
-  # if you use HTTPS for publication server (publication.spray.can.server.ssl-encryption == on)
+  # Set up TLS and client authentication as described in the README
+  #
   # put the certificate in a keystore and specify it's filename and password below
   # use the same password for the certificate and for the keystore
   server.keystore.location = ""
@@ -9,33 +10,10 @@ publication {
   # and specify it's filename and password here
   server.truststore.location = ""
   server.truststore.password = ""
-  spray.can.server {
-    ssl-encryption = "off"
-    request-timeout = 15s
-    pipelining-limit = 128
-    request-chunk-aggregation-limit = "30m"
-    parsing.max-content-length = "30m"
-  }
 }
 
 server.address="::0"
 rrdp.port = 7788
-
-spray.can.host-connector {
-  # The maximum number of parallel connections that an `HttpHostConnector`
-  # is allowed to establish to a host. Must be greater than zero.
-  max-connections = 1024
-
-  # If this setting is enabled, the `HttpHostConnector` pipelines requests
-  # across connections, otherwise only one single request can be "open"
-  # on a particular HTTP connection.
-  pipelining = on
-
-  # The time after which an idle `HttpHostConnector` (without open
-  # connections) will automatically terminate itself.
-  # Set to `infinite` to completely disable idle timeouts.
-  idle-timeout = 30 s
-}
 
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -22,6 +22,9 @@ class AppConfig {
   lazy val rrdpPort = getConfig.getInt("rrdp.port")
   lazy val rrdpRepositoryPath = getConfig.getString("locations.rrdp.repository.path")
   lazy val rrdpRepositoryUri  = getConfig.getString("locations.rrdp.repository.uri")
+
+  lazy val publicationEntitySizeLimit = getConfig.getMemorySize("publication.max-entity-size").toBytes
+
   lazy val unpublishedFileRetainPeriod = Duration(getConfig.getDuration("unpublished-file-retain-period", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
   lazy val snapshotSyncDelay = Duration(getConfig.getDuration("snapshot-sync-delay", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
   lazy val defaultTimeout = Duration(getConfig.getDuration("default.timeout", TimeUnit.MINUTES), TimeUnit.MINUTES)

--- a/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
@@ -64,10 +64,12 @@ class PublicationService(conf: AppConfig, metrics: Metrics)
         }
     }
 
-  val publicationRoutes =
-    path("") {
-      post {
-        parameter("clientId") { clientId =>          
+  logger.info(s"size limit on publication endpoint: ${conf.publicationEntitySizeLimit} bytes.")
+  // The exception to maximum entity size is only applied to publication endpoint, which has client TLS, preventing DOS attacks
+  val publicationRoutes = withSizeLimit(conf.publicationEntitySizeLimit) {
+      path("") {
+        post {
+          parameter("clientId") { clientId =>
             entity(as[BufferedSource]) { xmlMessage =>
               val mainPipeline = onComplete {
                 try {
@@ -107,7 +109,8 @@ class PublicationService(conf: AppConfig, metrics: Metrics)
                   complete(500, error.getMessage)
               }
             }
-          }        
+          }
+        }
       }
     }
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/util/SSLHelper.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/util/SSLHelper.scala
@@ -1,7 +1,7 @@
 package net.ripe.rpki.publicationserver.util
 
 import java.io.FileInputStream
-import java.security.KeyStore
+import java.security.{KeyStore, SecureRandom}
 
 import akka.http.scaladsl.{ConnectionContext, HttpsConnectionContext}
 import javax.net.ssl._
@@ -11,71 +11,40 @@ import org.slf4j.Logger
 import scala.util.Try
 
 class SSLHelper(conf: AppConfig, logger: Logger) {
+  /**
+   * Initialise a SSLContext using the settings from the config.
+   *
+   * This requires that both the truststore and keystore files are present and have valid passwords.
+   *
+   * @return a Success containing a valid SSL context, a Failure otherwise
+   */
   def connectionContext: Try[HttpsConnectionContext] = {
-    val sslContext = Try(SSLContext.getInstance("TLS"))
-    sslContext.foreach(_.init(getKeyManagers, getTrustManagers, null))
-    sslContext.flatMap(ctx => Try(ConnectionContext.https(ctx)))
+    Try(SSLContext.getInstance("TLS"))
+      .map(ctx => {
+        ctx.init(getKeyManagers.getKeyManagers, getTrustManagers.getTrustManagers, new SecureRandom)
+        ConnectionContext.https(ctx)
+      })
   }
 
-  private def getTrustManagers: Array[TrustManager] = {
-    if (conf.publicationServerTrustStoreLocation.isEmpty) {
-      logger.info(
-        "publication.server.truststore.location is not set, skipping truststore init"
-      )
-      null
-    } else {
-      val trustStore = KeyStore.getInstance("JKS")
-      val tsPassword: Array[Char] =
-        if (conf.publicationServerTrustStorePassword.isEmpty) {
-          null
-        } else {
-          conf.publicationServerTrustStorePassword.toCharArray
-        }
-      logger.info(
-        s"Loading HTTPS certificate from ${conf.publicationServerTrustStoreLocation}"
-      )
-      trustStore.load(
-        new FileInputStream(conf.publicationServerTrustStoreLocation),
-        tsPassword
-      )
-      val tmf = TrustManagerFactory.getInstance("SunX509")
-      tmf.init(trustStore)
-      tmf.getTrustManagers
-    }
+  private def getTrustManagers: TrustManagerFactory = {
+    require(!conf.publicationServerTrustStorePassword.isEmpty, "server.truststore.password is empty")
+    logger.info(s"Loading HTTPS certificate from ${conf.publicationServerTrustStoreLocation}")
+
+    val trustStore = KeyStore.getInstance("JKS")
+    trustStore.load(new FileInputStream(conf.publicationServerTrustStoreLocation), conf.publicationServerTrustStorePassword.toCharArray)
+    val tmf = TrustManagerFactory.getInstance("SunX509")
+    tmf.init(trustStore)
+    tmf
   }
 
-  private def getKeyManagers: Array[KeyManager] = {
-    if (conf.publicationServerKeyStoreLocation.isEmpty) {
-      if (conf.getConfig.getBoolean(
-        "publication.spray.can.server.ssl-encryption"
-      )) {
-        logger.error(
-          "publication.spray.can.server.ssl-encryption is ON, but publication.server.keystore.location " +
-            "is not defined. THIS WILL NOT WORK!"
-        )
-      } else {
-        logger.info(
-          "publication.server.keystore.location is not set, skipping keystore init"
-        )
-      }
-      null
-    } else {
-      val ksPassword = if (conf.publicationServerKeyStorePassword.isEmpty) {
-        null
-      } else {
-        conf.publicationServerKeyStorePassword.toCharArray
-      }
-      val keyStore = KeyStore.getInstance("JKS")
-      logger.info(
-        s"Loading HTTPS certificate from ${conf.publicationServerKeyStoreLocation}"
-      )
-      keyStore.load(
-        new FileInputStream(conf.publicationServerKeyStoreLocation),
-        ksPassword
-      )
-      val kmf = KeyManagerFactory.getInstance("SunX509")
-      kmf.init(keyStore, ksPassword)
-      kmf.getKeyManagers
-    }
+  private def getKeyManagers: KeyManagerFactory = {
+    require(!conf.publicationServerKeyStorePassword.isEmpty, "server.keystore.password is empty")
+    logger.info(s"Loading HTTPS certificate from ${conf.publicationServerKeyStoreLocation}")
+
+    val keyStore = KeyStore.getInstance("JKS")
+    keyStore.load(new FileInputStream(conf.publicationServerKeyStoreLocation), conf.publicationServerKeyStorePassword.toCharArray)
+    val kmf = KeyManagerFactory.getInstance("SunX509")
+    kmf.init(keyStore, conf.publicationServerKeyStorePassword.toCharArray)
+    kmf
   }
 }


### PR DESCRIPTION
With this change, the publication server **requires** HTTPS for the publication protocol with client authentication. This mitigates the risk of publication server from being launched without HTTPS in a production setting by accident (ROS 2.15.3).