### PR TITLE
Fix RRDP repository file attributes

### DIFF
--- a/src/main/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriter.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriter.scala
@@ -21,7 +21,7 @@ class RrdpRepositoryWriter extends Logging {
       Files.walkFileTree(Paths.get(rootDir), new RemoveAllVisitorExceptOneSession(sessionId.toString, timestamp))
   }
 
-  private val fileAttributes = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"))
+  val fileAttributes: FileAttributes = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"))
 
   def writeNotification(rootDir: String)(writeF : OutputStream => Unit): Option[FileTime] = {
     val root = getRootFolder(rootDir)

--- a/src/main/scala/net/ripe/rpki/publicationserver/fs/RsyncRepositoryWriter.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/fs/RsyncRepositoryWriter.scala
@@ -14,7 +14,7 @@ case class RsyncFsLocation(base: Path, relative: Path)
 class RsyncRepositoryWriter(conf: AppConfig) extends Logging {
 
   val directoryPermissions = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(conf.rsyncDirectoryPermissions))
-  val filePermissions = PosixFilePermissions.fromString(conf.rsyncFilePermissions)
+  val filePermissions: FilePermissions = PosixFilePermissions.fromString(conf.rsyncFilePermissions)
 
   val tempDirPrefix = "temp-"
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/package.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/package.scala
@@ -1,5 +1,7 @@
 package net.ripe.rpki
 
+import java.nio.file.attribute.{FileAttribute, PosixFilePermission, PosixFilePermissions}
+
 import com.softwaremill.macwire._
 
 package object publicationserver {
@@ -8,4 +10,9 @@ package object publicationserver {
     val repositoryPath = wire[AppConfig].rrdpRepositoryPath
   }
 
+  type FileAttributes = FileAttribute[java.util.Set[PosixFilePermission]]
+  type FilePermissions = java.util.Set[PosixFilePermission]
+
+  implicit def into(x: FilePermissions): FileAttributes =
+    PosixFilePermissions.asFileAttribute(x)
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -88,8 +88,8 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
 
     // Generate snapshot for the latest serial, we are only able to general the latest snapshot
     val ((snapshotHash, snapshotSize), snapshotDuration) = Time.timed {
-      withAtomicStream(snapshotPath(sessionId, serial)) { snapshotOs =>
-        writeRrdpSnapshot(sessionId, serial, snapshotOs)
+      withAtomicStream(snapshotPath(sessionId, serial) -> rrdpWriter.fileAttributes) {
+        writeRrdpSnapshot(sessionId, serial, _)
       }
     }
     logger.info(s"Generated snapshot $sessionId, $serial, took ${snapshotDuration}ms")
@@ -98,8 +98,8 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
     // Convenience function
     def writeDelta(s: Long) = {
       val ((deltaHash, deltaSize), deltaDuration) = Time.timed {
-        withAtomicStream(deltaPath(sessionId, serial)) { snapshotOs =>
-          writeRrdpDelta(sessionId, serial, snapshotOs)
+        withAtomicStream(deltaPath(sessionId, serial) -> rrdpWriter.fileAttributes) {
+          writeRrdpDelta(sessionId, serial, _)
         }
       }
       logger.info(s"Generated delta $sessionId/$s, took ${deltaDuration}ms")
@@ -132,8 +132,8 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
 
   private def initRrdpFS(thereAreChangesSinceTheLastFreeze: Boolean, sessionId: String, latestSerial: Long)(implicit session: DBSession) = {
     val ((snapshotHash, snapshotSize), snapshotDuration) = Time.timed {
-      withAtomicStream(snapshotPath(sessionId, latestSerial)) { snapshotOs =>
-        writeRrdpSnapshot(sessionId, latestSerial, snapshotOs)
+      withAtomicStream(snapshotPath(sessionId, latestSerial) -> rrdpWriter.fileAttributes) {
+        writeRrdpSnapshot(sessionId, latestSerial, _)
       }
     }
     logger.error(s"Wrote RRDP delta for ${sessionId}/${latestSerial}, took ${snapshotDuration}ms.")
@@ -141,8 +141,8 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
 
     if (thereAreChangesSinceTheLastFreeze) {
       val ((latestDeltaHash, latestDeltaSize), deltaDuration) = Time.timed {
-        withAtomicStream(deltaPath(sessionId, latestSerial)) { deltaOs =>
-          writeRrdpDelta(sessionId, latestSerial, deltaOs)
+        withAtomicStream(deltaPath(sessionId, latestSerial) -> rrdpWriter.fileAttributes) {
+          writeRrdpDelta(sessionId, latestSerial, _)
         }
       }
       logger.info(s"Generated delta $sessionId/$latestSerial, took ${deltaDuration}ms")
@@ -153,8 +153,8 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
 
     deltas.filter(_._1 != latestSerial).foreach { case (serial, _) =>
       val (_, deltaDuration) = Time.timed {
-        withAtomicStream(deltaPath(sessionId, serial)) { deltaOs =>
-          writeRrdpDelta(sessionId, serial, deltaOs)
+        withAtomicStream(deltaPath(sessionId, serial) -> rrdpWriter.fileAttributes) {
+          writeRrdpDelta(sessionId, serial, _)
         }
       }
       logger.info(s"Generated delta $sessionId/$serial, took ${deltaDuration}ms")
@@ -265,16 +265,18 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
     IOStream.string("</publish>\n", stream)
   }
 
-  def withAtomicStream(targetFile: Path)(f : HashingSizedStream => Unit) = {
-    val tmpFile = Files.createTempFile(targetFile.getParent, "", ".xml")
-    val tmpStream = new HashingSizedStream(new FileOutputStream(tmpFile.toFile))
-    try {
-      f(tmpStream)
-      Files.move(tmpFile, targetFile.toAbsolutePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-      tmpStream.summary
-    } finally {
-      tmpStream.close()
-      Files.deleteIfExists(tmpFile)
+  def withAtomicStream(target: (Path, FileAttributes))(f : HashingSizedStream => Unit) = target match {
+    case (targetFile, attrs) => {
+      val tmpFile = Files.createTempFile(targetFile.getParent, "", ".xml", attrs)
+      val tmpStream = new HashingSizedStream(new FileOutputStream(tmpFile.toFile))
+      try {
+        f(tmpStream)
+        Files.move(tmpFile, targetFile.toAbsolutePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+        tmpStream.summary
+      } finally {
+        tmpStream.close()
+        Files.deleteIfExists(tmpFile)
+      }
     }
   }
 


### PR DESCRIPTION
Apply the RRDP file attributes (from `RrdpRepositoryWriter`) to all RRDP
repository files written from the `DataFlusher`. This fixes possible issues with
default strict (or loose) masks, which is common in containers.