### PR TITLE
Update repositories on disk on a fixed interval

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ publication {
   server.truststore.location = ""
   server.truststore.password = ""
 
-  server.repository-write-interval = 10s
+  server.repository-write-interval = 120s
 
   # Maximum entity size, only applied to endpoints where needed, preferibly behind client tls
   max-entity-size = 512M

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,6 +11,8 @@ publication {
   server.truststore.location = ""
   server.truststore.password = ""
 
+  server.repository-write-interval = 10s
+
   # Maximum entity size, only applied to endpoints where needed, preferibly behind client tls
   max-entity-size = 512M
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -83,7 +83,4 @@ locations.rsync = {
 # time to keep unreferenced files to allow clients to continue downloading them
 unpublished-file-retain-period = 60m
 
-# do not write snapshot.xml files more often than "snapshot-sync-delay"
-snapshot-sync-delay = 10s
-
 default.timeout = 10m

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -26,7 +26,6 @@ class AppConfig {
   lazy val publicationEntitySizeLimit = getConfig.getMemorySize("publication.max-entity-size").toBytes
 
   lazy val unpublishedFileRetainPeriod = Duration(getConfig.getDuration("unpublished-file-retain-period", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
-  lazy val snapshotSyncDelay = Duration(getConfig.getDuration("snapshot-sync-delay", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
   lazy val defaultTimeout = Duration(getConfig.getDuration("default.timeout", TimeUnit.MINUTES), TimeUnit.MINUTES)
   lazy val serverAddress = if(getConfig.hasPath("server.address")) getConfig.getString("server.address") else "::0"
   lazy val rsyncRepositoryMapping : Map[URI, Path] = {

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -72,6 +72,11 @@ class AppConfig {
       case Success(data) => data
     }
 
+  lazy val repositoryFlushInterval = getConfig.getDuration(
+    "publication.server.repository-write-interval",
+    TimeUnit.MILLISECONDS
+  )
+
 }
 
 case class PgConfig(url: String, user: String, password: String)

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 import akka.http.scaladsl.settings.ServerSettings
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject, ConfigValue}
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.{Failure, Try, Success}
 
@@ -72,11 +72,13 @@ class AppConfig {
       case Success(data) => data
     }
 
-  lazy val repositoryFlushInterval = getConfig.getDuration(
-    "publication.server.repository-write-interval",
+  lazy val repositoryFlushInterval = FiniteDuration(
+    getConfig.getDuration(
+      "publication.server.repository-write-interval",
+      TimeUnit.MILLISECONDS
+    ),
     TimeUnit.MILLISECONDS
   )
-
 }
 
 case class PgConfig(url: String, user: String, password: String)

--- a/src/main/scala/net/ripe/rpki/publicationserver/Boot.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Boot.scala
@@ -17,6 +17,8 @@ import org.slf4j.Logger
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
+import net.ripe.rpki.publicationserver.repository.DataFlusher
+import akka.actor.Cancellable
 
 
 object Boot extends App with Logging {
@@ -41,12 +43,13 @@ object Boot extends App with Logging {
 }
 
 class PublicationServerApp(conf: AppConfig, https: ConnectionContext, logger: Logger) extends RRDPService {
-    
+
   implicit val system = ActorSystem.create(Math.abs(new ju.Random().nextLong()).toString)
   implicit val dispatcher = system.dispatcher
 
   var httpBinding: Future[ServerBinding] = _
   var httpsBinding: Future[ServerBinding] = _
+  var repositoryWriter: Cancellable = _
 
   val healthChecks = new HealthChecks(conf)
 
@@ -58,11 +61,18 @@ class PublicationServerApp(conf: AppConfig, https: ConnectionContext, logger: Lo
     val metrics = Metrics.get(registry)
     val metricsApi = new MetricsApi(registry)
 
-    val publicationService = new PublicationService(conf, metrics)
-
+    val dataFlusher = new DataFlusher(conf)
     // Run it asynchronously as it can be quite long, but we want
     // to start accepting HTTP(S) connections ASAP.
-    val asyncLongFSInit = Future { publicationService.initFS() }
+    val asyncLongFSInit = Future { dataFlusher.initFS() }
+
+    // Write repositories as a fixed interval
+    this.repositoryWriter = system.scheduler.scheduleAtFixedRate(
+      30.seconds, // Wait for full server startup and initialization
+      FiniteDuration(conf.repositoryFlushInterval, MILLISECONDS)
+    )(dataFlusher.updateFS _)
+
+    val publicationService = new PublicationService(conf, metrics)
 
     logger.info("Server address: " + conf.serverAddress)
 
@@ -72,7 +82,7 @@ class PublicationServerApp(conf: AppConfig, https: ConnectionContext, logger: Lo
       interface = conf.serverAddress,
       port = conf.publicationPort,
       connectionContext = https,
-      settings = conf.publicationServerSettings.get      
+      settings = conf.publicationServerSettings.get
     )
 
     this.httpBinding = Http().bindAndHandle(
@@ -99,11 +109,12 @@ class PublicationServerApp(conf: AppConfig, https: ConnectionContext, logger: Lo
   }
 
   def shutdown() = {
-       Await.result(httpBinding, 10.seconds)            
-            .terminate(hardDeadline = 3.seconds)
-            .flatMap(_ => 
-                Await.result(httpsBinding, 10.seconds)            
-                .terminate(hardDeadline = 3.seconds))
-            .flatMap(_ => system.terminate())
+      this.repositoryWriter.cancel()
+      Await.result(httpBinding, 10.seconds)
+           .terminate(hardDeadline = 3.seconds)
+           .flatMap(_ =>
+                Await.result(httpsBinding, 10.seconds)
+                     .terminate(hardDeadline = 3.seconds))
+           .flatMap(_ => system.terminate())
   }
 }


### PR DESCRIPTION
Replace on-demand writing of repository files with a fixed schedule. The
previous behavior caused publication messages to wait for FS updates, because
the `PublicationService` was used as lock target.

Rather than fixing the locking code, update the FS on a fixed interval. Checking
for changes in the database is quite cheap, and having a fixed schedule leads to
simpler code.

The interval is 10 seconds by default (in `reference.conf`) and can be adjusted
with `publication.server.repository-write-interval`.