### PR TITLE
Some more SQL cleanup

### DIFF
--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -376,8 +376,8 @@ CREATE OR REPLACE FUNCTION delete_old_versions()
 $$
 WITH deleted_versions AS (
          DELETE FROM versions
-             WHERE id NOT IN (SELECT id FROM reasonable_deltas)
-                 AND id NOT IN (SELECT id FROM latest_version)
+             WHERE NOT EXISTS (SELECT * FROM reasonable_deltas d WHERE d.id = versions.id)
+               AND NOT EXISTS (SELECT * FROM latest_version lv WHERE lv.id = versions.id)
              RETURNING *
      ),
      deleted_log AS (

--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -381,11 +381,10 @@ WITH deleted_versions AS (
              RETURNING *
      ),
      deleted_log AS (
-         DELETE FROM object_log ol
-             WHERE EXISTS(
-                     SELECT last_log_entry_id
+         DELETE FROM object_log
+             WHERE id <= (
+                     SELECT MAX(last_log_entry_id)
                      FROM deleted_versions
-                     WHERE ol.id <= last_log_entry_id
                  )
              RETURNING id
      ),

--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -281,7 +281,7 @@ CREATE OR REPLACE VIEW latest_version AS
 CREATE OR REPLACE VIEW reasonable_deltas AS
 SELECT z.*
 FROM (SELECT v.*,
-             SUM(delta_size) OVER (ORDER BY id DESC) AS total_delta_size
+             SUM(delta_size) OVER (PARTITION BY session_id ORDER BY id DESC) AS total_delta_size
       FROM versions v
      ) AS z,
      latest_version

--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -267,18 +267,18 @@ $body$
     LANGUAGE plpgsql;
 
 
+CREATE OR REPLACE VIEW latest_version AS
+  SELECT *
+    FROM versions
+    ORDER BY id DESC
+    LIMIT 1;
+
 -- Return deltas that reasonable to put into the notification.xml file.
 -- These has to be
 -- 1) deltas from the latest session
 -- 2) of total size not larger than the latest snapshot
 -- 3) having a definite hash (latest delta can have undefined hash until its file is generated and written)
 CREATE OR REPLACE VIEW reasonable_deltas AS
-WITH latest_version AS (
-    SELECT *
-    FROM versions
-    ORDER BY id DESC
-    LIMIT 1
-)
 SELECT z.*
 FROM (SELECT v.*,
              SUM(delta_size) OVER (ORDER BY id DESC) AS total_delta_size
@@ -307,9 +307,7 @@ BEGIN
         -- (if there's anything new in the object_log)
         WITH previous_version AS (
             SELECT id, session_id, serial, last_log_entry_id
-            FROM versions v
-            ORDER BY id DESC
-            LIMIT 1
+            FROM latest_version
         )
         INSERT
         INTO versions (session_id, serial, last_log_entry_id)
@@ -357,11 +355,9 @@ BEGIN
             SELECT MAX(id) IS NOT NULL
             FROM object_log
             WHERE id > (
-                SELECT last_log_entry_id
-                FROM versions
-                ORDER BY id DESC
-                LIMIT 1)
-        );
+                SELECT last_log_entry_id FROM latest_version
+                )
+            );
     ELSE
         RETURN EXISTS(SELECT * FROM object_log);
     END IF;
@@ -378,13 +374,7 @@ $body$
 CREATE OR REPLACE FUNCTION delete_old_versions()
     RETURNS SETOF versions AS
 $$
-WITH latest_version AS (
-    SELECT *
-    FROM versions
-    ORDER BY id DESC
-    LIMIT 1
-),
-     deleted_versions AS (
+WITH deleted_versions AS (
          DELETE FROM versions
              WHERE id NOT IN (SELECT id FROM reasonable_deltas)
                  AND id NOT IN (SELECT id FROM latest_version)

--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -390,21 +390,17 @@ WITH deleted_versions AS (
      ),
      deleted_objects AS (
          DELETE FROM objects o
-             WHERE o.id IN (
-                 SELECT id
-                 FROM objects o
-                 WHERE o.deleted_at IS NOT NULL
-                   AND NOT EXISTS(
-                         SELECT *
-                         FROM object_log
-                         WHERE new_object_id = o.id
-                     )
-                   AND NOT EXISTS(
-                         SELECT *
-                         FROM object_log
-                         WHERE old_object_id = o.id
-                     )
-             )
+             WHERE o.deleted_at IS NOT NULL
+               AND NOT EXISTS(
+                     SELECT *
+                     FROM object_log
+                     WHERE new_object_id = o.id
+               )
+               AND NOT EXISTS(
+                     SELECT *
+                     FROM object_log
+                     WHERE old_object_id = o.id
+               )
              RETURNING id
      )
 SELECT *

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
@@ -85,9 +85,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
   }
 
   def getCurrentSessionInfo(implicit session: DBSession) = {
-    sql"""SELECT session_id, serial
-          FROM versions
-          ORDER BY id DESC LIMIT 1"""
+    sql"SELECT session_id, serial FROM latest_version"
       .map(rs => (rs.string(1), rs.long(2)))
       .single()
       .apply()
@@ -245,6 +243,3 @@ object PgStore extends Logging {
   }
 
 }
-
-
-


### PR DESCRIPTION
Reduce duplication by having a `latest_version` view. We may want to replace this with an actual table that we update whenever a new version becomes "active".

Replaces `NOT IN` conditions with `NOT EXISTS` (see https://wiki.postgresql.org/wiki/Don%27t_Do_This#Why_not.3F_5).

Simplified `DELETE` statements in `delete_old_versions`.

None of these changes should change the semantics.

Also, we can rewrite `delete_old_versions` to use a temporary table instead of a big common table expression:

```plpgsql
CREATE OR REPLACE FUNCTION delete_old_versions()
    RETURNS SETOF versions AS
$$
BEGIN
    CREATE TEMPORARY TABLE deleted_versions ON COMMIT DROP AS
        SELECT * FROM versions
         WHERE NOT EXISTS (SELECT * FROM reasonable_deltas d WHERE d.id = versions.id)
           AND NOT EXISTS (SELECT * FROM latest_version lv WHERE lv.id = versions.id);

    DELETE FROM versions WHERE id IN (SELECT id FROM deleted_versions);

    DELETE FROM object_log
     WHERE id <= (SELECT MAX(last_log_entry_id) FROM deleted_versions);

    DELETE FROM objects
     WHERE deleted_at IS NOT NULL
       AND NOT EXISTS (SELECT * FROM object_log WHERE new_object_id = objects.id)
       AND NOT EXISTS (SELECT * FROM object_log WHERE old_object_id = objects.id);

    -- Does not return from the function, but appends results to the return value:
    -- https://www.postgresql.org/docs/12/plpgsql-control-structures.html#id-1.8.8.8.3.4
    RETURN QUERY SELECT * FROM deleted_versions;

    DROP TABLE deleted_versions;
END
$$ LANGUAGE plpgsql;
```