### PR TITLE
Fix XML parsing bottleneck

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"        %% "akka-slf4j"            % akkaV,
     "org.scalatest"            %% "scalatest"             % "3.1.4"   % "test",
     "org.mockito"               % "mockito-all"           % "1.10.19" % "test",
-    "org.codehaus.woodstox"     % "woodstox-core-asl"     % "4.4.1",
+    "com.fasterxml.woodstox"    % "woodstox-core"         % "6.2.4",
     "com.sun.xml.bind"          % "jaxb1-impl"            % "2.2.5.1",
     "ch.qos.logback"            % "logback-classic"       % "1.2.3",
     "com.softwaremill.macwire" %% "macros"                % "2.3.3" % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,10 @@ scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 // use sbt assembly plugin and create a fat jar with a predictable name.
 mainClass in assembly := Some("net.ripe.rpki.publicationserver.Boot")
 assemblyJarName in assembly := "rpki-publication-server.jar"
+assemblyMergeStrategy in assembly := {
+  case "module-info.class" => MergeStrategy.discard
+  case x => (assemblyMergeStrategy in assembly).value (x)
+}
 test in assembly := {}
 
 parallelExecution in Test := false

--- a/src/main/scala/net/ripe/rpki/publicationserver/parsing/StaxParser.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/parsing/StaxParser.scala
@@ -50,8 +50,7 @@ case class UnknownEvent(code: Int) extends StaxEvent
 object StaxEvent {
 
   def readFrom(reader: XMLStreamReader): StaxEvent = {
-    // Unfortunately the synchronizing is needed because the Woodstox parser's validating is not thread safe, not even across readers.
-    getClass.synchronized(reader.next()) match {
+    reader.next() match {
 
       case XMLStreamConstants.START_ELEMENT =>
         val label = reader.getLocalName


### PR DESCRIPTION
Update abandoned codehaus woodstox to the fasterxml implementation and drop the
synchronization around `reader.next`. While woodstox parsers themselves are
not thread-safe, concurrent parsing is safe by using different parsers in
different threads.

Removing the synchronization allows for parsing and validating concurrent
requests, lifting a huge bottleneck from the publication endpoint.