### PR TITLE
Always generate latest delta on RRDP initialisation

### DIFF
--- a/src/main/scala/net/ripe/rpki/publicationserver/model/package.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/model/package.scala
@@ -5,6 +5,8 @@ import java.net.URI
 import net.ripe.rpki.publicationserver.Binaries.Bytes
 
 package object model {
+  val INITIAL_SERIAL = 1L
+
   case class ClientId(value: String)
 
   case class BaseError(code: String, message: String)

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -271,6 +271,7 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
     val tmpStream = new HashingSizedStream(new FileOutputStream(tmpFile.toFile))
     try {
       f(tmpStream)
+      tmpStream.flush()
       Files.move(tmpFile, targetFile.toAbsolutePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
       tmpStream.summary
     } finally {

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -153,9 +153,11 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
       // Delta for the latest serial was already created above, so we can skip it here.
       if serial != latestSerial
     } {
-      withAtomicStream(deltaPath(sessionId, serial), rrdpWriter.fileAttributes) {
-        writeRrdpDelta(sessionId, serial, _)
-      }
+      val (deltaHash, deltaSize) =
+        withAtomicStream(deltaPath(sessionId, serial), rrdpWriter.fileAttributes) {
+          writeRrdpDelta(sessionId, serial, _)
+        }
+      pgStore.updateDeltaInfo(sessionId, serial, deltaHash, deltaSize)
     }
 
     val (_, duration) = Time.timed {

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import net.ripe.rpki.publicationserver.Binaries.Bytes
 import net.ripe.rpki.publicationserver._
 import net.ripe.rpki.publicationserver.fs.{Rrdp, RrdpRepositoryWriter, RsyncRepositoryWriter}
+import net.ripe.rpki.publicationserver.model.INITIAL_SERIAL
 import net.ripe.rpki.publicationserver.store.postresql.PgStore
 import net.ripe.rpki.publicationserver.util.Time
 import scalikejdbc.DBSession
@@ -134,7 +135,7 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
       }
     pgStore.updateSnapshotInfo(sessionId, latestSerial, snapshotHash, snapshotSize)
 
-    if (latestSerial > 1) {
+    if (latestSerial > INITIAL_SERIAL) {
       // When there are changes since the last freeze the latest delta might not yet exist, so ensure it gets created.
       // The `getReasonableDeltas` query below will then decide which deltas (if any) should be included in the
       // notification.xml file.

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
@@ -17,5 +17,7 @@ class HashingSizedStream(val os: OutputStream) extends Hashing {
 
   def summary = (Hash(bytesToHex(digest.digest())), size)
 
+  def flush() = os.flush()
+
   def close() = os.close()
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -137,7 +137,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     val (sessionId, serial) = verifySessionAndSerial
 
-    serial should be(1L)
+    serial should be(INITIAL_SERIAL)
 
     val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -137,6 +137,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     val (sessionId, serial) = verifySessionAndSerial
 
+    serial should be(1L)
+
     val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
@@ -144,17 +146,9 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
       </snapshot>"""
     }
 
-    val deltaBytes = verifyExpectedDelta(sessionId, serial) {
-      s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-          <publish uri="${uri1}">${base64_1}</publish>
-          <publish uri="${uri2}">${base64_2}</publish>
-      </delta>"""
-    }
-
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
             <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="1" uri="http://localhost:7788/${sessionId}/${serial}/delta.xml" hash="${hash(Bytes(deltaBytes)).hash}"/>
           </notification>"""
     }
   }


### PR DESCRIPTION
Note: if we want to be more defensive we may want to generate delta files also for versions where delta hash and size are `NULL`. These are skipped by the `getReasonableDeltas` query. This case shouldn't occur except for the last frozen version which we handle specially anyway, but ...

Note: the ``Should update rrdp and rsync when DB is modified by `another instance` in the meantime`` test in `DataFlusherTest` is flaky. 