### PR TITLE
Clarify that TLS is done by reverse proxy and that implementation follows a draft of RFC8181

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 RPKI Publication Server
 =======================
 
-This is the RIPE NCC's implementation of [A Publication Protocol for the Resource Public Key Infrastructure] 
-(https://tools.ietf.org/html/draft-weiler-sidr-publication) and [RPKI Repository Delta Protocol]
-(https://tools.ietf.org/wg/sidr/draft-ietf-sidr-delta-protocol/).
+This is the RIPE NCC's implementation of [RFC 8182 - The RPKI Repository Delta Protocol]
+(https://tools.ietf.org/html/rfc8182) and a draft of [RFC 8181 - A Publication Protocol for the Resource Public Key Infrastructure] 
+(https://tools.ietf.org/html/rfc8181).
+
+This implementation differs from the final specification in the following key areas:
+  * Mutual TLS is used instead of CMS wrapping of objects.
+  * Publication XML messages follow [draft-ietf-sidr-publication-07](https://tools.ietf.org/html/draft-ietf-sidr-publication-07) instead of RFC 8181.
+
+The publication server is meant to be used with a single trusted client (c.f.
+multiple delegated Certification Authorities).
+
+The produced RRDP repository is in accordance with RFC 8182 and is accepted by
+all known Relying Party implementations.
 
 Building the project
 --------------------

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This implementation differs from the final specification in the following key ar
 The publication server is meant to be used with a single trusted client (c.f.
 multiple delegated Certification Authorities).
 
-The publication server relies on a reverse proxy for TLS. Since all Relying Party
-implementations require HTTPS urls for the RRDP repository, for production usage
-the publication server **MUST** be deployed behind a reverse proxy that performs
-TLS termination, with a trusted network link between reverse proxy and publication
-server.
+The publication server relies on a reverse proxy for TLS on the port used for
+RRDP. Since all Relying Party implementations require HTTPS urls for the RRDP
+repository, for production usage the publication server **MUST** be deployed
+behind a reverse proxy that performs TLS termination, with a trusted network
+link between reverse proxy and publication server.
 
 The produced RRDP repository is in accordance with RFC 8182 and is accepted by
 all known Relying Party implementations.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This implementation differs from the final specification in the following key ar
 The publication server is meant to be used with a single trusted client (c.f.
 multiple delegated Certification Authorities).
 
+The publication server relies on a reverse proxy for TLS. Since all Relying Party
+implementations require HTTPS urls for the RRDP repository, for production usage
+the publication server **MUST** be deployed behind a reverse proxy that performs
+TLS termination, with a trusted network link between reverse proxy and publication
+server.
+
 The produced RRDP repository is in accordance with RFC 8182 and is accepted by
 all known Relying Party implementations.
 


### PR DESCRIPTION
Addresses the comments on:
  * RFC 8182 4.3 HTTPS between publication server and RP, and
  * The usage of v3 of the publication protocol.