### PR TITLE
Use randomised names for RRDP files.

### DIFF
--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -295,8 +295,6 @@ ORDER BY z.id DESC;
 CREATE OR REPLACE FUNCTION freeze_version() RETURNS SETOF versions AS
 $body$
 BEGIN
-    -- NOTE This one is safe from race conditions only if
-    -- lock_versions is called before in the same transaction.
     PERFORM lock_versions();
 
     IF EXISTS(SELECT * FROM versions) THEN

--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -40,23 +40,37 @@ CREATE INDEX idx_object_log_old_object_id ON object_log (old_object_id) WHERE ol
 
 CREATE TABLE versions
 (
-    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    session_id        TEXT   NOT NULL,
-    serial            BIGINT NOT NULL,
-    last_log_entry_id BIGINT NOT NULL,
-    snapshot_hash     TEXT CHECK (snapshot_hash ~ '^[0-9a-f]{64}$'),
-    delta_hash        TEXT CHECK (delta_hash ~ '^[0-9a-f]{64}$'),
-    snapshot_size     BIGINT,
-    delta_size        BIGINT,
-    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    id                 BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    session_id         TEXT                     NOT NULL,
+    serial             BIGINT                   NOT NULL,
+    last_log_entry_id  BIGINT                   NOT NULL,
+    snapshot_file_name TEXT,
+    delta_file_name    TEXT,
+    snapshot_hash      TEXT CHECK (snapshot_hash ~ '^[0-9a-f]{64}$'),
+    delta_hash         TEXT CHECK (delta_hash ~ '^[0-9a-f]{64}$'),
+    snapshot_size      BIGINT,
+    delta_size         BIGINT,
+    created_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
     CONSTRAINT delta_field_in_sync CHECK (
-            delta_size IS NULL AND delta_hash IS NULL OR
-            delta_size IS NOT NULL AND delta_hash IS NOT NULL
+                delta_size IS NULL
+                AND delta_hash IS NULL
+                AND delta_file_name IS NULL
+            OR
+                delta_size IS NOT NULL
+                    AND delta_hash IS NOT NULL
+                    AND delta_file_name IS NOT NULL
         ),
     CONSTRAINT snapshot_field_in_sync CHECK (
-            snapshot_hash IS NULL AND snapshot_size IS NULL OR
-            snapshot_hash IS NOT NULL AND snapshot_size IS NOT NULL
+                snapshot_size IS NULL
+                AND snapshot_hash IS NULL
+                AND snapshot_file_name IS NULL
+            OR
+                snapshot_size IS NOT NULL
+                    AND snapshot_hash IS NOT NULL
+                    AND snapshot_file_name IS NOT NULL
         )
 );
+
 
 CREATE UNIQUE INDEX idx_versions_session_id_serial ON versions (session_id, serial);

--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -5,7 +5,7 @@ DROP TABLE IF EXISTS versions CASCADE;
 CREATE TABLE objects
 (
     id         BIGINT  GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    hash       TEXT    NOT NULL CHECK (hash ~ '^[0-9a-f]{64}$'),
+    hash       BYTEA   NOT NULL CHECK (LENGTH(hash) = 32),
     url        TEXT    NOT NULL,
     client_id  TEXT    NOT NULL,
     content    BYTEA   NOT NULL,
@@ -25,8 +25,8 @@ CREATE TABLE versions
     serial             BIGINT                   NOT NULL,
     snapshot_file_name TEXT,
     delta_file_name    TEXT,
-    snapshot_hash      TEXT CHECK (snapshot_hash ~ '^[0-9a-f]{64}$'),
-    delta_hash         TEXT CHECK (delta_hash ~ '^[0-9a-f]{64}$'),
+    snapshot_hash      BYTEA  CHECK (LENGTH(snapshot_hash) = 32),
+    delta_hash         BYTEA  CHECK (LENGTH(delta_hash) = 32),
     snapshot_size      BIGINT,
     delta_size         BIGINT,
     created_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),

--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -17,33 +17,12 @@ CREATE UNIQUE INDEX idx_objects_url ON objects (url) WHERE deleted_at IS NULL;
 CREATE UNIQUE INDEX idx_objects_hash ON objects (hash);
 CREATE INDEX idx_objects_client_id ON objects (client_id);
 
-CREATE TABLE object_log
-(
-    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    operation     TEXT   NOT NULL,
-    new_object_id BIGINT,
-    old_object_id BIGINT,
-    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    CHECK (CASE operation
-           WHEN 'INS' THEN old_object_id IS NULL AND new_object_id IS NOT NULL
-           WHEN 'UPD' THEN new_object_id IS NOT NULL AND new_object_id IS NOT NULL
-           WHEN 'DEL' THEN old_object_id IS NOT NULL AND new_object_id IS NULL
-           ELSE FALSE
-           END
-        ),
-    FOREIGN KEY (new_object_id) REFERENCES objects (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
-    FOREIGN KEY (old_object_id) REFERENCES objects (id) ON DELETE RESTRICT ON UPDATE RESTRICT
-);
-
-CREATE INDEX idx_object_log_new_object_id ON object_log (new_object_id) WHERE new_object_id IS NOT NULL;
-CREATE INDEX idx_object_log_old_object_id ON object_log (old_object_id) WHERE old_object_id IS NOT NULL;
 
 CREATE TABLE versions
 (
     id                 BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     session_id         TEXT                     NOT NULL,
     serial             BIGINT                   NOT NULL,
-    last_log_entry_id  BIGINT                   NOT NULL,
     snapshot_file_name TEXT,
     delta_file_name    TEXT,
     snapshot_hash      TEXT CHECK (snapshot_hash ~ '^[0-9a-f]{64}$'),
@@ -72,5 +51,29 @@ CREATE TABLE versions
         )
 );
 
-
 CREATE UNIQUE INDEX idx_versions_session_id_serial ON versions (session_id, serial);
+
+
+CREATE TABLE object_log
+(
+    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    operation     TEXT   NOT NULL,
+    new_object_id BIGINT,
+    old_object_id BIGINT,
+    version_id    BIGINT,
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CHECK (CASE operation
+           WHEN 'INS' THEN old_object_id IS NULL AND new_object_id IS NOT NULL
+           WHEN 'UPD' THEN new_object_id IS NOT NULL AND new_object_id IS NOT NULL
+           WHEN 'DEL' THEN old_object_id IS NOT NULL AND new_object_id IS NULL
+           ELSE FALSE
+           END
+        ),
+    FOREIGN KEY (new_object_id) REFERENCES objects (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    FOREIGN KEY (old_object_id) REFERENCES objects (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    FOREIGN KEY (version_id) REFERENCES versions (id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+CREATE INDEX idx_object_log_new_object_id ON object_log (new_object_id) WHERE new_object_id IS NOT NULL;
+CREATE INDEX idx_object_log_old_object_id ON object_log (old_object_id) WHERE old_object_id IS NOT NULL;
+CREATE INDEX idx_object_log_version_id ON object_log (version_id);

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -56,11 +56,11 @@ class AppConfig {
                         getConfig.getString("postgresql.password")
                     )      
 
-  def snapshotUrl(sessionId: String, serial: Long) =
-    rrdpRepositoryUri + "/" + sessionId + "/" + serial + "/snapshot.xml"
+  def snapshotUrl(sessionId: String, serial: Long, snapshotFileName: String) =
+    s"$rrdpRepositoryUri/$sessionId/$serial/$snapshotFileName"
 
-  def deltaUrl(sessionId: String, serial: Long) =
-    rrdpRepositoryUri + "/" + sessionId + "/" + serial + "/delta.xml"
+  def deltaUrl(sessionId: String, serial: Long, deltaFileName: String) =
+    s"$rrdpRepositoryUri/$sessionId/$serial/$deltaFileName"
 
   lazy val writeRsync = isMode("rsync")
   lazy val writeRrdp = isMode("rrdp")

--- a/src/main/scala/net/ripe/rpki/publicationserver/Binaries.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Binaries.scala
@@ -1,8 +1,7 @@
 package net.ripe.rpki.publicationserver
 
 import java.io.{InputStream, OutputStream}
-import java.util.{Base64 => B64}
-
+import java.util.{Arrays, Base64 => B64}
 import com.google.common.io.ByteStreams
 
 object Binaries {
@@ -13,12 +12,12 @@ object Binaries {
   case class Base64(value: String)
 
   case class Bytes(value: Array[Byte]) {
-    override def equals(obj: Any): Boolean = {
-      if (canEqual(obj)) {
-        obj.asInstanceOf[Bytes].value.sameElements(this.value)
-      } else
-        false
+    override def equals(obj: Any): Boolean = obj match {
+      case that: Bytes => that.canEqual(this) && Arrays.equals(this.value, that.value)
+      case _ => false
     }
+
+    override def hashCode(): Int = Arrays.hashCode(value)
   }
 
   object Bytes {

--- a/src/main/scala/net/ripe/rpki/publicationserver/Boot.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Boot.scala
@@ -10,7 +10,7 @@ import akka.util.Timeout
 import com.softwaremill.macwire._
 import io.prometheus.client._
 import net.ripe.rpki.publicationserver.metrics._
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import net.ripe.rpki.publicationserver.util.SSLHelper
 import org.slf4j.Logger
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
@@ -2,7 +2,7 @@ package net.ripe.rpki.publicationserver
 
 import java.net.InetAddress
 
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import spray.json._
 
 import scala.util.Try

--- a/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import net.ripe.rpki.publicationserver.metrics.Metrics
 import net.ripe.rpki.publicationserver.model._
 import net.ripe.rpki.publicationserver.parsing.PublicationMessageParser
-import net.ripe.rpki.publicationserver.store.postresql.{PgStore, RollbackException}
+import net.ripe.rpki.publicationserver.store.postgresql.{PgStore, RollbackException}
 
 import java.io.ByteArrayInputStream
 import java.net.URI

--- a/src/main/scala/net/ripe/rpki/publicationserver/RRDPService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/RRDPService.scala
@@ -34,11 +34,8 @@ trait RRDPService extends RepositoryPath {
         }
       }
     } ~
-      path(JavaUUID / IntNumber / "snapshot.xml") { (sessionId, serial) =>
-        serveImmutableContent(s"$repositoryPath/$sessionId/$serial/snapshot.xml")
-      } ~
-      path(JavaUUID / IntNumber / "delta.xml") { (sessionId, serial) =>
-        serveImmutableContent(s"$repositoryPath/$sessionId/$serial/delta.xml")
+      path(JavaUUID / IntNumber) { (sessionId, serial) =>
+        serveImmutableContent(s"$repositoryPath/$sessionId/$serial")
       }
 
   val monitoringRoutes: Route =
@@ -51,13 +48,13 @@ trait RRDPService extends RepositoryPath {
   val rrdpAndMonitoringRoutes: Route = rrdpRoutes ~ monitoringRoutes
 
 
-  private def serveImmutableContent(filename: => String) = {
+  private def serveImmutableContent(directory: => String) = {
     respondWithHeader(
         `Cache-Control`(
             CacheDirectives.`max-age`(oneDayInSeconds), 
             CacheDirectives.`no-transform`)) {
                 get {
-                    getFromFile(filename)(ContentTypeResolver.withDefaultCharset(HttpCharsets.`US-ASCII`))
+                  getFromDirectory(directory)(ContentTypeResolver.withDefaultCharset(HttpCharsets.`US-ASCII`))
                 }    
         }
   }

--- a/src/main/scala/net/ripe/rpki/publicationserver/RRDPService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/RRDPService.scala
@@ -1,12 +1,12 @@
 package net.ripe.rpki.publicationserver
 
-import java.nio.file.{Files, Paths}
-
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{CacheDirectives, `Cache-Control`}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.ContentTypeResolver
+
+import java.nio.file.{Files, Paths}
 
 
 
@@ -34,7 +34,7 @@ trait RRDPService extends RepositoryPath {
         }
       }
     } ~
-      path(JavaUUID / IntNumber) { (sessionId, serial) =>
+      pathPrefix(JavaUUID / IntNumber) { (sessionId, serial) =>
         serveImmutableContent(s"$repositoryPath/$sessionId/$serial")
       }
 
@@ -51,11 +51,11 @@ trait RRDPService extends RepositoryPath {
   private def serveImmutableContent(directory: => String) = {
     respondWithHeader(
         `Cache-Control`(
-            CacheDirectives.`max-age`(oneDayInSeconds), 
+            CacheDirectives.`max-age`(oneDayInSeconds),
             CacheDirectives.`no-transform`)) {
                 get {
                   getFromDirectory(directory)(ContentTypeResolver.withDefaultCharset(HttpCharsets.`US-ASCII`))
-                }    
+                }
         }
   }
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/fs/Rrdp.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/fs/Rrdp.scala
@@ -1,14 +1,18 @@
 package net.ripe.rpki.publicationserver.fs
 
+import java.nio.file.Path
+
 object Rrdp {
   val notificationFilename = "notification.xml"
 
   def deltaFileNameWithExtra(s: String) = s"delta-$s.xml"
   def snapshotFileNameWithExtra(s: String) = s"snapshot-$s.xml"
 
-  def isDelta(f: String): Boolean =
-    f.startsWith("delta-") && f.endsWith(".xml")
+  def isSnapshot(f: Path): Boolean = isSpecificXml(f, "snapshot")
+  def isDelta(f: Path): Boolean =  isSpecificXml(f, "delta")
 
-  def isSnapshot(f: String): Boolean =
-    f.startsWith("snapshot-") && f.endsWith(".xml")
+  private def isSpecificXml(f: Path, prefix: String) = {
+    val localName = f.getFileName.toString
+    localName.startsWith(prefix + "-") && localName.endsWith(".xml")
+  }
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/fs/Rrdp.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/fs/Rrdp.scala
@@ -2,6 +2,13 @@ package net.ripe.rpki.publicationserver.fs
 
 object Rrdp {
   val notificationFilename = "notification.xml"
-  val snapshotFilename = "snapshot.xml"
-  val deltaFilename = "delta.xml"
+
+  def deltaFileNameWithExtra(s: String) = s"delta-$s.xml"
+  def snapshotFileNameWithExtra(s: String) = s"snapshot-$s.xml"
+
+  def isDelta(f: String): Boolean =
+    f.startsWith("delta-") && f.endsWith(".xml")
+
+  def isSnapshot(f: String): Boolean =
+    f.startsWith("snapshot-") && f.endsWith(".xml")
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriter.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriter.scala
@@ -39,10 +39,6 @@ class RrdpRepositoryWriter extends Logging {
 
   private def getRootFolder(rootDir: String): Path = Files.createDirectories(Paths.get(rootDir))
 
-  def deleteSessionFile(rootDir: String, sessionId: UUID, serial: Long, name: String): Boolean = {
-    Files.deleteIfExists(Paths.get(rootDir, sessionId.toString, serial.toString, name))
-  }
-
   def deleteSnapshotsOlderThan(rootDir: String, timestamp: FileTime, latestSerial: Long): Unit = {
     Files.walkFileTree(Paths.get(rootDir), new RemovingFileVisitor(timestamp, f => Rrdp.isSnapshot(f.getFileName.toString), latestSerial))
   }

--- a/src/main/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriter.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriter.scala
@@ -40,7 +40,7 @@ class RrdpRepositoryWriter extends Logging {
   private def getRootFolder(rootDir: String): Path = Files.createDirectories(Paths.get(rootDir))
 
   def deleteSnapshotsOlderThan(rootDir: String, timestamp: FileTime, latestSerial: Long): Unit = {
-    Files.walkFileTree(Paths.get(rootDir), new RemovingFileVisitor(timestamp, f => Rrdp.isSnapshot(f.getFileName.toString), latestSerial))
+    Files.walkFileTree(Paths.get(rootDir), new RemovingFileVisitor(timestamp, Rrdp.isSnapshot, latestSerial))
   }
 
   def cleanUpEmptyDir(rootDir: String, sessionId: UUID, serial: Long) = {
@@ -53,7 +53,7 @@ class RrdpRepositoryWriter extends Logging {
   def deleteDelta(rootDir: String, sessionId: UUID, serial: Long): AnyVal = {
     val sessionSerialDir = Paths.get(rootDir, sessionId.toString, serial.toString)
     Files.list(sessionSerialDir).
-      filter(f => Rrdp.isDelta(f.toString)).
+      filter(Rrdp.isDelta).
       forEach(f => Files.deleteIfExists(f))
     cleanUpEmptyDir(rootDir, sessionId, serial)
   }

--- a/src/main/scala/net/ripe/rpki/publicationserver/model/package.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/model/package.scala
@@ -22,9 +22,9 @@ package object model {
 
   sealed trait QueryPdu
 
-  case class PublishQ(uri: URI, tag: Option[String], hash: Option[String], bytes: Bytes) extends QueryPdu
+  case class PublishQ(uri: URI, tag: Option[String], hash: Option[Hash], bytes: Bytes) extends QueryPdu
 
-  case class WithdrawQ(uri: URI, tag: Option[String], hash: String) extends QueryPdu
+  case class WithdrawQ(uri: URI, tag: Option[String], hash: Hash) extends QueryPdu
 
   case class ListQ(tag: Option[String] = None) extends QueryPdu
 
@@ -34,7 +34,7 @@ package object model {
 
   case class WithdrawR(uri: URI, tag: Option[String]) extends ReplyPdu
 
-  case class ListR(uri: URI, hash: String, tag: Option[String]) extends ReplyPdu
+  case class ListR(uri: URI, hash: Hash, tag: Option[String]) extends ReplyPdu
 
   case class ReportError(code: String, message: Option[String]) extends ReplyPdu
 
@@ -75,8 +75,8 @@ package object model {
           case PublishR(uri, None) => s"""<publish uri="${attr(uri.toASCIIString)}"/>"""
           case WithdrawR(uri, Some(tag)) => s"""<withdraw tag="${attr(tag)}" uri="${attr(uri.toASCIIString)}"/>"""
           case WithdrawR(uri, None) => s"""<withdraw uri="${attr(uri.toASCIIString)}"/>"""
-          case ListR(uri, hash, Some(tag)) => s"""<list tag="${attr(tag)}" uri="${attr(uri.toASCIIString)}" hash="$hash"/>"""
-          case ListR(uri, hash, None) => s"""<list uri="${attr(uri.toASCIIString)}" hash="$hash"/>"""
+          case ListR(uri, hash, Some(tag)) => s"""<list tag="${attr(tag)}" uri="${attr(uri.toASCIIString)}" hash="${hash.toHex}"/>"""
+          case ListR(uri, hash, None) => s"""<list uri="${attr(uri.toASCIIString)}" hash="${hash.toHex}"/>"""
           case ReportError(code, message) =>
             s"""<report_error error_code="$code">
           ${message.map(content).getOrElse("Unspecified error")}

--- a/src/main/scala/net/ripe/rpki/publicationserver/parsing/PublicationMessageParser.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/parsing/PublicationMessageParser.scala
@@ -3,6 +3,7 @@ package net.ripe.rpki.publicationserver.parsing
 import java.net.URI
 
 import net.ripe.rpki.publicationserver.Binaries.{Base64, Bytes}
+import net.ripe.rpki.publicationserver.Hash
 import net.ripe.rpki.publicationserver.model._
 
 import scala.annotation.tailrec
@@ -38,7 +39,7 @@ class PublicationMessageParser extends MessageParser[Message] {
                 val trimmedText = trim(lastText)
                 try {
                   val bytes = Bytes.fromBase64(Base64(trimmedText))
-                  val pdu = PublishQ(uri = new URI(lastAttributes("uri")), tag = lastAttributes.get("tag"), hash = lastAttributes.get("hash"), bytes = bytes)
+                  val pdu = PublishQ(uri = new URI(lastAttributes("uri")), tag = lastAttributes.get("tag"), hash = lastAttributes.get("hash").map(Hash.fromHex), bytes = bytes)
                   Right(pdu)
                 } catch {
                   case _: Exception =>
@@ -46,7 +47,7 @@ class PublicationMessageParser extends MessageParser[Message] {
                 }
 
               case "withdraw" =>
-                val pdu = WithdrawQ(uri = new URI(lastAttributes("uri")), tag = lastAttributes.get("tag"), hash = lastAttributes("hash"))
+                val pdu = WithdrawQ(uri = new URI(lastAttributes("uri")), tag = lastAttributes.get("tag"), hash = Hash.fromHex(lastAttributes("hash")))
                 Right(pdu)
 
               case "list" => // TODO ??? implement tags for list query

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -252,10 +252,10 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
     IOStream.string("</notification>", stream)
   }
 
-  private val random = new scala.util.Random()
+  private val random = new scala.util.Random(new java.security.SecureRandom())
 
   private def generateRandomPart: String = {
-    random.shuffle(random.alphanumeric.map(c => c.toLower).take(20).toList).mkString
+    random.alphanumeric.map(c => c.toLower).take(20).mkString
   }
 
   def deltaPathKnownName(sessionId: String, serial: Long, deltaFileName: String): Path = {

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -5,7 +5,7 @@ import net.ripe.rpki.publicationserver.Binaries.Bytes
 import net.ripe.rpki.publicationserver._
 import net.ripe.rpki.publicationserver.fs.{Rrdp, RrdpRepositoryWriter, RsyncRepositoryWriter}
 import net.ripe.rpki.publicationserver.model.INITIAL_SERIAL
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import net.ripe.rpki.publicationserver.util.Time
 import scalikejdbc.DBSession
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -341,13 +341,14 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
     //
     // First remove the ones that are more than `oldEnough`
     logger.info(s"Removing all the sessions in RRDP repository except for $sessionId")
-    rrdpWriter.cleanSessionsOlderThanExceptForOne(conf.rrdpRepositoryPath, oldEnough, sessionId)
+    rrdpWriter.deleteSessionsOlderThanExceptForOne(conf.rrdpRepositoryPath, oldEnough, sessionId)
+    rrdpWriter.deleteEmptyDirectories(conf.rrdpRepositoryPath)
 
     // Wait for the time T and delete those which are older than `now`
     system.scheduler.scheduleOnce(conf.unpublishedFileRetainPeriod) {
       logger.info(s"Removing all the older sessions in RRDP repository except for $sessionId")
-      rrdpWriter.cleanSessionsOlderThanExceptForOne(conf.rrdpRepositoryPath, FileTime.from(now), sessionId)
-      ()
+      rrdpWriter.deleteSessionsOlderThanExceptForOne(conf.rrdpRepositoryPath, FileTime.from(now), sessionId)
+      rrdpWriter.deleteEmptyDirectories(conf.rrdpRepositoryPath)
     }
   }
 
@@ -366,6 +367,7 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
           val oldestSerial = serials.min
           logger.info(s"Removing snapshots from the session $sessionId older than $oldEnough and having serial number older than $oldestSerial")
           rrdpWriter.deleteSnapshotsOlderThan(conf.rrdpRepositoryPath, oldEnough, oldestSerial + 1)
+          rrdpWriter.deleteEmptyDirectories(conf.rrdpRepositoryPath)
         })
     }
   }

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
@@ -15,7 +15,7 @@ class HashingSizedStream(val os: OutputStream) extends Hashing {
     os.write(bytes)
   }
 
-  def summary = (Hash(bytesToHex(digest.digest())), size)
+  def summary = (Hash(digest.digest()), size)
 
   def flush() = os.flush()
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
@@ -1,4 +1,4 @@
-package net.ripe.rpki.publicationserver.store.postresql
+package net.ripe.rpki.publicationserver.store.postgresql
 
 import net.ripe.rpki.publicationserver.Binaries.Bytes
 import net.ripe.rpki.publicationserver._
@@ -159,6 +159,10 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
           val error = parse(json).extract[BaseError]
           throw RollbackException(error)
       }
+    }
+
+    if (changeSet.pdus.isEmpty) {
+      return
     }
 
     inRepeatableReadTx { implicit session =>

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
@@ -29,13 +29,13 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
   }
 
   def getState = DB.localTx { implicit session =>
-    sql"SELECT * FROM current_state ORDER BY url"
+    sql"SELECT hash, url, client_id, content FROM current_state ORDER BY url"
       .map { rs =>
-        val hash = Hash(rs.string(1))
-        val uri = URI.create(rs.string(2))
+        val hash = Hash(rs.bytes(1))
+        val url = URI.create(rs.string(2))
         val clientId = ClientId(rs.string(3))
-        val bytes = Bytes.fromStream(rs.binaryStream(4))
-        uri -> (bytes, hash, clientId)
+        val content = Bytes.fromStream(rs.binaryStream(4))
+        url -> (content, hash, clientId)
       }
       .list()
       .apply()
@@ -49,7 +49,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
       .map { rs =>
         val operation = rs.string(1)
         val uri = URI.create(rs.string(2))
-        val hash = rs.stringOpt(3).map(Hash)
+        val hash = rs.bytesOpt(3).map(bs => Hash(bs))
         val bytes = rs.binaryStreamOpt(4).map(Bytes.fromStream)
         (operation, uri, hash, bytes)
       }
@@ -64,7 +64,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
           ORDER BY url ASC"""
       .foreach { rs =>
         val uri = URI.create(rs.string(1))
-        val hash = Hash(rs.string(2))
+        val hash = Hash(rs.bytes(2))
         val bytes = Bytes.fromStream(rs.binaryStream(3))
         f(uri, hash, bytes)
       }
@@ -78,7 +78,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
       .foreach { rs =>
         val operation = rs.string(1)
         val uri = URI.create(rs.string(2))
-        val oldHash = rs.stringOpt(3).map(Hash)
+        val oldHash = rs.bytesOpt(3).map(bs => Hash(bs))
         val bytes = rs.binaryStreamOpt(4).map(Bytes.fromStream)
         f(operation, uri, oldHash, bytes)
       }
@@ -89,11 +89,11 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
 
   def getCurrentSessionInfo(implicit session: DBSession) = {
 
-    def toSnapshotInfo(name: Option[String], hash: Option[String], size: Option[Long]) =
+    def toSnapshotInfo(name: Option[String], hash: Option[Array[Byte]], size: Option[Long]) =
       for (n <- name; h <- hash; s <- size)
         yield SnapshotInfo(n, Hash(h), s)
 
-    def toDeltaInfo(name: Option[String], hash: Option[String], size: Option[Long]) =
+    def toDeltaInfo(name: Option[String], hash: Option[Array[Byte]], size: Option[Long]) =
       for (n <- name; h <- hash; s <- size)
         yield DeltaInfo(n, Hash(h), s)
 
@@ -104,8 +104,8 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
       .map(rs => (
         rs.string(1),
         rs.long(2),
-        toSnapshotInfo(rs.stringOpt(3), rs.stringOpt(4), rs.longOpt(5)),
-        toDeltaInfo(rs.stringOpt(6), rs.stringOpt(7), rs.longOpt(8))
+        toSnapshotInfo(rs.stringOpt(3), rs.bytesOpt(4), rs.longOpt(5)),
+        toDeltaInfo(rs.stringOpt(6), rs.bytesOpt(7), rs.longOpt(8))
       ))
       .single()
       .apply()
@@ -118,7 +118,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
           ORDER BY serial DESC"""
       .map { rs =>
         (rs.long(1),
-          Hash(rs.string(2)),
+          Hash(rs.bytes(2)),
           rs.string(3))
       }
       .list()
@@ -127,7 +127,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
 
   def updateSnapshotInfo(sessionId: String, serial: Long, snapshotFileName: String, hash: Hash, size: Long)(implicit session: DBSession): Unit = {
     sql"""UPDATE versions SET
-            snapshot_hash = ${hash.hash},
+            snapshot_hash = ${hash.toBytes},
             snapshot_size = $size,
             snapshot_file_name = $snapshotFileName
           WHERE session_id = $sessionId AND serial = $serial"""
@@ -137,7 +137,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
 
   def updateDeltaInfo(sessionId: String, serial: Long, deltaFileName: String, hash: Hash, size: Long)(implicit session: DBSession): Unit = {
     sql"""UPDATE versions SET
-            delta_hash = ${hash.hash},
+            delta_hash = ${hash.toBytes},
             delta_size = $size,
             delta_file_name = $deltaFileName
           WHERE session_id = $sessionId AND serial = $serial"""
@@ -173,12 +173,12 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
       changeSet.pdus.foreach {
         case PublishQ(uri, _, None, Bytes(bytes)) =>
           executeSql(
-            sql"SELECT create_object(${bytes},  ${uri.toString}, ${clientId.value})",
+            sql"SELECT create_object(${bytes}, ${uri.toString}, ${clientId.value})",
             metrics.publishedObject(),
             metrics.failedToAdd())
         case PublishQ(uri, _, Some(oldHash), Bytes(bytes)) =>
           executeSql(
-            sql"SELECT replace_object(${bytes}, ${oldHash}, ${uri.toString}, ${clientId.value})",
+            sql"SELECT replace_object(${bytes}, ${oldHash.toBytes}, ${uri.toString}, ${clientId.value})",
             {
               metrics.withdrawnObject()
               metrics.publishedObject()
@@ -186,7 +186,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
             metrics.failedToReplace())
         case WithdrawQ(uri, _, hash) =>
           executeSql(
-            sql"SELECT delete_object(${uri.toString}, ${hash}, ${clientId.value})",
+            sql"SELECT delete_object(${uri.toString}, ${hash.toBytes}, ${clientId.value})",
             metrics.withdrawnObject(),
             metrics.failedToDelete())
       }
@@ -239,7 +239,7 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
   def list(clientId: ClientId) = inRepeatableReadTx { implicit session =>
     sql"""SELECT url, hash FROM current_state
            WHERE client_id = ${clientId.value}"""
-      .map(rs => (rs.string(1), rs.string(2)))
+      .map(rs => (rs.string(1), Hash(rs.bytes(2))))
       .list()
       .apply()
   }

--- a/src/test/scala/net/ripe/rpki/publicationserver/HashingTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HashingTest.scala
@@ -4,9 +4,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class HashingTest extends AnyFunSuite with Matchers with Hashing {
-  test("should parse publish message") {
-    stringify(null) should be("")
-    stringify(Array()) should be("")
-    stringify(Array(0x11, 0x22, 0x00, 0xAB, 0xFF).map(_.toByte)) should be("112200abff")
+  test("should encode bytes to hex") {
+    bytesToHex(Array()) should be("")
+    bytesToHex(Array(0x11, 0x22, 0x00, 0xAB, 0xFF).map(_.toByte)) should be("112200abff")
   }
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
@@ -1,6 +1,6 @@
 package net.ripe.rpki.publicationserver
 
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import org.mockito.Mockito._
 import spray.json._
 

--- a/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
@@ -12,7 +12,7 @@ import io.prometheus.client.CollectorRegistry
 import net.ripe.rpki.publicationserver.Binaries.Bytes
 import net.ripe.rpki.publicationserver.metrics.Metrics
 import net.ripe.rpki.publicationserver.model._
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import org.scalatest.BeforeAndAfter
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
@@ -82,7 +82,7 @@ abstract class PublicationServerBaseTest extends AnyFunSuite with BeforeAndAfter
         </publish>
 
       case PublishQ(uri, None, Some(hash), b) =>
-        <publish uri={uri.toASCIIString} hash={hash}>
+        <publish uri={uri.toASCIIString} hash={hash.toHex}>
           {Bytes.toBase64(b).value}
         </publish>
 
@@ -92,15 +92,15 @@ abstract class PublicationServerBaseTest extends AnyFunSuite with BeforeAndAfter
         </publish>
 
       case PublishQ(uri, Some(tag), Some(hash), b) =>
-        <publish uri={uri.toASCIIString} hash={hash} tag={tag}>
+        <publish uri={uri.toASCIIString} hash={hash.toHex} tag={tag}>
           {Bytes.toBase64(b).value}
         </publish>
 
       case WithdrawQ(uri, None, hash) =>
-          <withdraw uri={uri.toASCIIString} hash={hash}/>
+          <withdraw uri={uri.toASCIIString} hash={hash.toHex}/>
 
       case WithdrawQ(uri, Some(tag), hash) =>
-          <withdraw uri={uri.toASCIIString} hash={hash} tag={tag}/>
+          <withdraw uri={uri.toASCIIString} hash={hash.toHex} tag={tag}/>
 
       case ListQ(None) => <list/>
       case ListQ(Some(tag)) => <list tag={tag}/>

--- a/src/test/scala/net/ripe/rpki/publicationserver/PublicationServiceTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/PublicationServiceTest.scala
@@ -59,7 +59,7 @@ class PublicationServiceTest extends PublicationServerBaseTest with Hashing with
     val pdus = Seq(PublishQ(new URI(certUrl), None, None, bytes))
     updateState(service, pdus)
 
-    val withdrawXml = xml(WithdrawQ(new URI(certUrl), tag = None, hash(bytes).hash))
+    val withdrawXml = xml(WithdrawQ(new URI(certUrl), tag = None, hashOf(bytes)))
     val withdrawXmlResponse = getFile("/withdrawResponse.xml")
 
     POST("/?clientId=1234", withdrawXml.mkString) ~> service.publicationRoutes ~> check {
@@ -75,7 +75,7 @@ class PublicationServiceTest extends PublicationServerBaseTest with Hashing with
     val pdus = Seq(PublishQ(new URI("rsync://wombat.example/Alice/blCrcCp9ltyPDNzYKPfxc.cer"), None, None, bytes))
     updateState(service, pdus)
 
-    val withdrawXml = xml(WithdrawQ(new URI("rsync://wombat.example/Alice/blCrcCp9ltyPDNzYKPfxc.cer"), tag = None, hash(bytes).hash.toLowerCase))
+    val withdrawXml = xml(WithdrawQ(new URI("rsync://wombat.example/Alice/blCrcCp9ltyPDNzYKPfxc.cer"), tag = None, hashOf(bytes)))
     val withdrawXmlResponse = getFile("/withdrawResponse.xml")
 
     POST("/?clientId=1234", withdrawXml.mkString) ~> service.publicationRoutes ~> check {
@@ -92,7 +92,7 @@ class PublicationServiceTest extends PublicationServerBaseTest with Hashing with
     val pdus = Seq(PublishQ(uri, None, None, bytes))
     updateState(service, pdus)
 
-    val publishWithHashXml = xml(PublishQ(uri, None, Some(hash(bytes).hash), bytes))
+    val publishWithHashXml = xml(PublishQ(uri, None, Some(hashOf(bytes)), bytes))
     val publishWithHashXmlResponse = getFile("/publishWithHashXmlResponse.xml")
 
     POST("/?clientId=1234", publishWithHashXml.mkString) ~> service.publicationRoutes ~> check {
@@ -109,7 +109,7 @@ class PublicationServiceTest extends PublicationServerBaseTest with Hashing with
     val pdus = Seq(PublishQ(uri, None, None, bytes))
     updateState(service, pdus)
 
-    val publishWithHashXml = xml(PublishQ(uri, None, Some(hash(bytes).hash.toLowerCase), bytes))
+    val publishWithHashXml = xml(PublishQ(uri, None, Some(hashOf(bytes)), bytes))
     val publishWithHashXmlResponse = getFile("/publishWithHashXmlResponse.xml")
 
     POST("/?clientId=1234", publishWithHashXml.mkString) ~> service.publicationRoutes ~> check {
@@ -125,7 +125,7 @@ class PublicationServiceTest extends PublicationServerBaseTest with Hashing with
     val pdus = Seq(PublishQ(new URI("rsync://wombat.example/Alice/blCrcCp9ltyPDNzYKPfxc.cer"), None, None, bytes))
     updateState(service, pdus)
 
-    val withdrawXml = xml(WithdrawQ(new URI("rsync://wombat.example/Alice/blCrcCp9ltyPDNzYKPfxc.cer"), tag = Some("123"), hash(bytes).hash))
+    val withdrawXml = xml(WithdrawQ(new URI("rsync://wombat.example/Alice/blCrcCp9ltyPDNzYKPfxc.cer"), tag = Some("123"), hashOf(bytes)))
     val withdrawXmlResponse = getFile("/withdrawWithTagResponse.xml")
 
     POST("/?clientId=1234", withdrawXml.mkString) ~> publicationService.publicationRoutes ~> check {

--- a/src/test/scala/net/ripe/rpki/publicationserver/fs/RemovingEmptyDirectoriesVisitorTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/fs/RemovingEmptyDirectoriesVisitorTest.scala
@@ -1,93 +1,30 @@
 package net.ripe.rpki.publicationserver.fs
 
-import java.nio.file.{Paths, FileVisitResult, Path, Files}
-import java.nio.file.attribute.{BasicFileAttributes, FileTime}
-
 import net.ripe.rpki.publicationserver.PublicationServerBaseTest
 
-class RemovingFileVisitorTest extends PublicationServerBaseTest {
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
 
-  val someFilename = Paths.get("somename")
-  val someTimestamp = FileTime.fromMillis(1)
+class RemovingEmptyDirectoriesVisitorTest extends PublicationServerBaseTest {
 
+  test("should remove empty directories recursively and leave non-empty") {
 
-  test("isCreatedBefore should return true for file older than timestamp") {
-    val file = tempFile
-    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 0)
+    val rootDir = Files.createTempDirectory("test_remove_empty_dir_visitor")
+    deleteOnExit(rootDir)
 
-    FSUtil.isCreatedBefore(file, timestampAfter(file)) should be(true)
-  }
+    Files.createDirectory(Paths.get(rootDir.toString, "x"))
+    Files.createDirectory(Paths.get(rootDir.toString, "x", "y"))
+    Files.createDirectory(Paths.get(rootDir.toString, "x", "y", "foo"))
+    Files.createDirectory(Paths.get(rootDir.toString, "x", "y", "foo", "bar"))
+    Files.createDirectory(Paths.get(rootDir.toString, "z"))
 
-  test("isCreatedBefore should return false for file yonger than timestamp") {
-    val file = tempFile
-    val subject = new RemovingFileVisitor(timestampBefore(file), f => f.getFileName == file.getFileName, 0)
+    Files.write(Paths.get(rootDir.toString, "z", "file.txt"), "something".getBytes(StandardCharsets.UTF_8))
 
-    FSUtil.isCreatedBefore(file, timestampBefore(file)) should be(false)
-  }
+    Files.walkFileTree(rootDir, new RemoveEmptyDirectoriesVisitor())
 
-  test("isEmptyDir should return true for empty dir") {
-    val dir = tempDirectory
-    FSUtil.isEmptyDir(dir) should be(true)
-  }
-
-  test("isEmptyDir should return false for non-empty dir") {
-    val dir = tempDirectory
-    Files.createFile(dir.resolve("filler")).toFile.deleteOnExit()
-    FSUtil.isEmptyDir(dir) should be(false)
-  }
-
-  test("should not remove other old files") {
-    val file = tempFile
-    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == someFilename, 0)
-
-    subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
-
-    Files.exists(file) should be(true)
-  }
-
-  test("should remove old file") {
-    val file = tempFile
-    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 0)
-
-    subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
-
-    Files.exists(file) should be(false)
-  }
-
-  test("should not remove old file in case it has passed serial number in it") {
-    val file = {
-      val directory = Files.createTempDirectory("test_remove_visitor")
-      deleteOnExit(directory)
-
-      Files.createDirectory(Paths.get(directory.toString, "1"))
-      Files.createDirectory(Paths.get(directory.toString, "1", "snapshot.xml"))
-    }
-    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 1)
-
-    subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
-
-    Files.exists(file) should be(true)
-  }
-
-
-  def timestampAfter(file: Path): FileTime = {
-    FileTime.from(Files.getLastModifiedTime(file).toInstant.plusSeconds(10))
-  }
-
-  def timestampBefore(file: Path): FileTime = {
-    FileTime.from(Files.getLastModifiedTime(file).toInstant.minusSeconds(10))
-  }
-
-  def tempDirectory: Path = {
-    val directory: Path = Files.createTempDirectory("test_remove_dir")
-    deleteOnExit(directory)
-    directory
-  }
-
-  def tempFile: Path = {
-    val file: Path = Files.createTempFile("test_remove_file", "")
-    deleteOnExit(file)
-    file
+    Paths.get(rootDir.toString, "x").toFile.exists() should be(false)
+    Paths.get(rootDir.toString, "z").toFile.exists() should be(true)
+    Paths.get(rootDir.toString, "z", "file.txt").toFile.exists() should be(true)
   }
 
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/fs/RemovingEmptyDirectoriesVisitorTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/fs/RemovingEmptyDirectoriesVisitorTest.scala
@@ -1,0 +1,93 @@
+package net.ripe.rpki.publicationserver.fs
+
+import java.nio.file.{Paths, FileVisitResult, Path, Files}
+import java.nio.file.attribute.{BasicFileAttributes, FileTime}
+
+import net.ripe.rpki.publicationserver.PublicationServerBaseTest
+
+class RemovingFileVisitorTest extends PublicationServerBaseTest {
+
+  val someFilename = Paths.get("somename")
+  val someTimestamp = FileTime.fromMillis(1)
+
+
+  test("isCreatedBefore should return true for file older than timestamp") {
+    val file = tempFile
+    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 0)
+
+    FSUtil.isCreatedBefore(file, timestampAfter(file)) should be(true)
+  }
+
+  test("isCreatedBefore should return false for file yonger than timestamp") {
+    val file = tempFile
+    val subject = new RemovingFileVisitor(timestampBefore(file), f => f.getFileName == file.getFileName, 0)
+
+    FSUtil.isCreatedBefore(file, timestampBefore(file)) should be(false)
+  }
+
+  test("isEmptyDir should return true for empty dir") {
+    val dir = tempDirectory
+    FSUtil.isEmptyDir(dir) should be(true)
+  }
+
+  test("isEmptyDir should return false for non-empty dir") {
+    val dir = tempDirectory
+    Files.createFile(dir.resolve("filler")).toFile.deleteOnExit()
+    FSUtil.isEmptyDir(dir) should be(false)
+  }
+
+  test("should not remove other old files") {
+    val file = tempFile
+    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == someFilename, 0)
+
+    subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
+
+    Files.exists(file) should be(true)
+  }
+
+  test("should remove old file") {
+    val file = tempFile
+    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 0)
+
+    subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
+
+    Files.exists(file) should be(false)
+  }
+
+  test("should not remove old file in case it has passed serial number in it") {
+    val file = {
+      val directory = Files.createTempDirectory("test_remove_visitor")
+      deleteOnExit(directory)
+
+      Files.createDirectory(Paths.get(directory.toString, "1"))
+      Files.createDirectory(Paths.get(directory.toString, "1", "snapshot.xml"))
+    }
+    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 1)
+
+    subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
+
+    Files.exists(file) should be(true)
+  }
+
+
+  def timestampAfter(file: Path): FileTime = {
+    FileTime.from(Files.getLastModifiedTime(file).toInstant.plusSeconds(10))
+  }
+
+  def timestampBefore(file: Path): FileTime = {
+    FileTime.from(Files.getLastModifiedTime(file).toInstant.minusSeconds(10))
+  }
+
+  def tempDirectory: Path = {
+    val directory: Path = Files.createTempDirectory("test_remove_dir")
+    deleteOnExit(directory)
+    directory
+  }
+
+  def tempFile: Path = {
+    val file: Path = Files.createTempFile("test_remove_file", "")
+    deleteOnExit(file)
+    file
+  }
+
+}

--- a/src/test/scala/net/ripe/rpki/publicationserver/fs/RemovingFileVisitorTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/fs/RemovingFileVisitorTest.scala
@@ -13,14 +13,14 @@ class RemovingFileVisitorTest extends PublicationServerBaseTest {
 
   test("isCreatedBefore should return true for file older than timestamp") {
     val file = tempFile
-    val subject = new RemovingFileVisitor(timestampAfter(file), file.getFileName, 0)
+    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 0)
 
     FSUtil.isCreatedBefore(file, timestampAfter(file)) should be(true)
   }
 
   test("isCreatedBefore should return false for file yonger than timestamp") {
     val file = tempFile
-    val subject = new RemovingFileVisitor(timestampBefore(file), file.getFileName, 0)
+    val subject = new RemovingFileVisitor(timestampBefore(file), f => f.getFileName == file.getFileName, 0)
 
     FSUtil.isCreatedBefore(file, timestampBefore(file)) should be(false)
   }
@@ -38,7 +38,7 @@ class RemovingFileVisitorTest extends PublicationServerBaseTest {
 
   test("should not remove other old files") {
     val file = tempFile
-    val subject = new RemovingFileVisitor(timestampAfter(file), someFilename, 0)
+    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == someFilename, 0)
 
     subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
 
@@ -47,7 +47,7 @@ class RemovingFileVisitorTest extends PublicationServerBaseTest {
 
   test("should remove old file") {
     val file = tempFile
-    val subject = new RemovingFileVisitor(timestampAfter(file), file.getFileName, 0)
+    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 0)
 
     subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
 
@@ -62,7 +62,7 @@ class RemovingFileVisitorTest extends PublicationServerBaseTest {
       Files.createDirectory(Paths.get(directory.toString, "1"))
       Files.createDirectory(Paths.get(directory.toString, "1", "snapshot.xml"))
     }
-    val subject = new RemovingFileVisitor(timestampAfter(file), file.getFileName, 1)
+    val subject = new RemovingFileVisitor(timestampAfter(file), f => f.getFileName == file.getFileName, 1)
 
     subject.visitFile(file, Files.readAttributes(file, classOf[BasicFileAttributes])) should be(FileVisitResult.CONTINUE)
 

--- a/src/test/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriterTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriterTest.scala
@@ -26,7 +26,7 @@ class RrdpRepositoryWriterTest extends PublicationServerBaseTest {
     val timestamp = System.currentTimeMillis()
     val repoFiles = setupTestRepo(timestamp)
     val deleteTimestamp = timestamp - 5000
-    val (toDelete, toKeep) = repoFiles.partition(f => f.endsWith("snapshot.xml") && mtimeIsBefore(f, deleteTimestamp))
+    val (toDelete, toKeep) = repoFiles.partition(f => Rrdp.isSnapshot(f.getFileName.toString) && mtimeIsBefore(f, deleteTimestamp))
     assume(toDelete.nonEmpty)
     assume(toKeep.nonEmpty)
 
@@ -42,9 +42,9 @@ class RrdpRepositoryWriterTest extends PublicationServerBaseTest {
       serialDir <- (1 to 10).map(_ => Files.createTempDirectory(sessionDir, "serial"))
     } yield {
       val fileTime: FileTime = FileTime.fromMillis(timestamp - Random.nextInt(10 * 1000))
-      val delta = Files.createFile(serialDir.resolve("delta.xml"))
+      val delta = Files.createFile(serialDir.resolve("delta-1.xml"))
       Files.setLastModifiedTime(delta, fileTime)
-      val snapshot = Files.createFile(serialDir.resolve("snapshot.xml"))
+      val snapshot = Files.createFile(serialDir.resolve("snapshot-1.xml"))
       Files.setLastModifiedTime(snapshot, fileTime)
       Seq(delta, snapshot)
     }).flatten :+ Files.createFile(rootDir.resolve("notification.xml"))

--- a/src/test/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriterTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/fs/RrdpRepositoryWriterTest.scala
@@ -26,7 +26,7 @@ class RrdpRepositoryWriterTest extends PublicationServerBaseTest {
     val timestamp = System.currentTimeMillis()
     val repoFiles = setupTestRepo(timestamp)
     val deleteTimestamp = timestamp - 5000
-    val (toDelete, toKeep) = repoFiles.partition(f => Rrdp.isSnapshot(f.getFileName.toString) && mtimeIsBefore(f, deleteTimestamp))
+    val (toDelete, toKeep) = repoFiles.partition(f => Rrdp.isSnapshot(f) && mtimeIsBefore(f, deleteTimestamp))
     assume(toDelete.nonEmpty)
     assume(toKeep.nonEmpty)
 

--- a/src/test/scala/net/ripe/rpki/publicationserver/integration/PublicationIntegrationTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/integration/PublicationIntegrationTest.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.nio.file._
 
 import net.ripe.rpki.publicationserver.Binaries.Base64
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import net.ripe.rpki.publicationserver.util.SSLHelper
 import net.ripe.rpki.publicationserver._
 import org.slf4j.LoggerFactory

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -55,7 +55,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     val (sessionId, serial) = verifySessionAndSerial
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
       </snapshot>"""
     }
@@ -69,17 +69,14 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
           </notification>"""
     }
   }
 
   test("initFS function must be idempotent") {
-    val flusher = newFlusher()
-    flusher.initFS()
-
     def verifyRrdpFiles(sessionId: String, serial: Long) = {
-      val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+      val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
         s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
       </snapshot>"""
       }
@@ -92,11 +89,14 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
       }
 
       verifyExpectedNotification {
-        s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+        s"""<notification version="1" session_id="$sessionId" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
+            <snapshot uri="http://localhost:7788/$sessionId/$serial/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
           </notification>"""
       }
     }
+
+    val flusher = newFlusher()
+    flusher.initFS()
 
     waitForRrdpCleanup()
 
@@ -139,7 +139,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     serial should be(INITIAL_SERIAL)
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
           <publish uri="${uri2}">${base64_2}</publish>
@@ -148,7 +148,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
           </notification>"""
     }
   }
@@ -178,7 +178,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     val (sessionId, serial) = verifySessionAndSerial
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
           <publish uri="${uri2}">${base64_2}</publish>
@@ -187,7 +187,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyDeltaDoesntExist(sessionId, serial - 1)
 
-    val deltaBytes2 = verifyExpectedDelta(sessionId, serial) {
+    val (deltaName2, deltaBytes2) = verifyExpectedDelta(sessionId, serial) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri2}">${base64_2}</publish>
       </delta>"""
@@ -195,8 +195,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/delta.xml" hash="${hash(Bytes(deltaBytes2)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName2" hash="${hash(Bytes(deltaBytes2)).hash}"/>
           </notification>"""
     }
   }
@@ -237,7 +237,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     val (sessionId, serial) = verifySessionAndSerial
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
           <publish uri="${uri2}">${base64_2}</publish>
@@ -247,13 +247,13 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyDeltaDoesntExist(sessionId, serial-2)
 
-    val deltaBytes2 = verifyExpectedDelta(sessionId, serial-1) {
+    val (deltaName2, deltaBytes2) = verifyExpectedDelta(sessionId, serial-1) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial-1}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri2}">${base64_2}</publish>
       </delta>"""
     }
 
-    val deltaBytes3 = verifyExpectedDelta(sessionId, serial) {
+    val (deltaName3, deltaBytes3) = verifyExpectedDelta(sessionId, serial) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri3}">${base64_3}</publish>
       </delta>"""
@@ -261,9 +261,9 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/delta.xml" hash="${hash(Bytes(deltaBytes3)).hash}"/>
-            <delta serial="${serial-1}" uri="http://localhost:7788/${sessionId}/${serial-1}/delta.xml" hash="${hash(Bytes(deltaBytes2)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName3" hash="${hash(Bytes(deltaBytes3)).hash}"/>
+            <delta serial="${serial-1}" uri="http://localhost:7788/${sessionId}/${serial-1}/$deltaName2" hash="${hash(Bytes(deltaBytes2)).hash}"/>
           </notification>"""
     }
   }
@@ -288,14 +288,14 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     val (sessionId, serial) = verifySessionAndSerial
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
           <publish uri="${uri2}">${base64_2}</publish>
       </snapshot>"""
     }
 
-    val deltaBytes = verifyExpectedDelta(sessionId, serial) {
+    val (deltaName, deltaBytes) = verifyExpectedDelta(sessionId, serial) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
           <publish uri="${uri2}">${base64_2}</publish>
@@ -304,8 +304,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/delta.xml" hash="${hash(Bytes(deltaBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hash(Bytes(deltaBytes)).hash}"/>
           </notification>"""
     }
   }
@@ -344,14 +344,14 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     val (sessionId, serial) = verifySessionAndSerial
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
           <publish uri="${uri2}">${base64_2}</publish>
       </snapshot>"""
     }
 
-    val deltaBytes = verifyExpectedDelta(sessionId, serial) {
+    val (deltaName, deltaBytes) = verifyExpectedDelta(sessionId, serial) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
           <publish uri="${uri2}">${base64_2}</publish>
@@ -360,8 +360,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/delta.xml" hash="${hash(Bytes(deltaBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hash(Bytes(deltaBytes)).hash}"/>
           </notification>"""
     }
   }
@@ -402,7 +402,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     val (sessionId, serial) = verifySessionAndSerial
     serial should be(4)
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri1}">${base64_1}</publish>
           <publish uri="${uri2}">${base64_2}</publish>
@@ -415,13 +415,13 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     verifyDeltaDoesntExist(sessionId, serial - 3)
     verifyDeltaDoesntExist(sessionId, serial - 2)
 
-    val deltaBytes2 = verifyExpectedDelta(sessionId, serial - 1) {
+    val (deltaName2, deltaBytes2) = verifyExpectedDelta(sessionId, serial - 1) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial - 1}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri2}">${base64_2}</publish>
       </delta>"""
     }
 
-    val deltaBytes3 = verifyExpectedDelta(sessionId, serial) {
+    val (deltaName3, deltaBytes3) = verifyExpectedDelta(sessionId, serial) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
           <publish uri="${uri3}">${base64_3}</publish>
       </delta>"""
@@ -429,9 +429,9 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/delta.xml" hash="${hash(Bytes(deltaBytes3)).hash}"/>
-            <delta serial="${serial - 1}" uri="http://localhost:7788/${sessionId}/${serial - 1}/delta.xml" hash="${hash(Bytes(deltaBytes2)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName3" hash="${hash(Bytes(deltaBytes3)).hash}"/>
+            <delta serial="${serial - 1}" uri="http://localhost:7788/${sessionId}/${serial - 1}/$deltaName2" hash="${hash(Bytes(deltaBytes2)).hash}"/>
           </notification>"""
     }
   }
@@ -475,7 +475,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     verifyDeltaDoesntExist(sessionId, serial - 2)
     verifyDeltaDoesntExist(sessionId, serial - 1)
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp"></snapshot>"""
     }
 
@@ -487,7 +487,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
           </notification>"""
     }
   }
@@ -507,14 +507,14 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     val (bytes2, base64_2) = TestBinaries.generateObject()
 
     def verifyRrpdFiles(sessionId : String, serial: Long) = {
-      val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+      val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
         s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
               <publish uri="${uri1}">${base64_1}</publish>
               <publish uri="${uri2}">${base64_2}</publish>
           </snapshot>"""
       }
 
-      val deltaBytes = verifyExpectedDelta(sessionId, serial) {
+      val (deltaName, deltaBytes) = verifyExpectedDelta(sessionId, serial) {
         s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
               <publish uri="${uri1}">${base64_1}</publish>
               <publish uri="${uri2}">${base64_2}</publish>
@@ -523,8 +523,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
       verifyExpectedNotification {
         s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/delta.xml" hash="${hash(Bytes(deltaBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hash(Bytes(deltaBytes)).hash}"/>
           </notification>"""
       }
     }
@@ -589,7 +589,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     verifyDeltaDoesntExist(sessionId, serial - 2)
     verifyDeltaDoesntExist(sessionId, serial - 1)
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp"></snapshot>"""
     }
 
@@ -601,7 +601,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
           </notification>"""
     }
   }
@@ -682,7 +682,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     verifyDeltaDoesntExist(sessionId, serial - 2)
     verifyDeltaDoesntExist(sessionId, serial - 1)
 
-    val snapshotBytes = verifyExpectedSnapshot(sessionId, serial) {
+    val (snapshotName, snapshotBytes) = verifyExpectedSnapshot(sessionId, serial) {
       s"""<snapshot version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp"></snapshot>"""
     }
 
@@ -694,7 +694,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/snapshot.xml" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
           </notification>"""
     }
   }
@@ -707,7 +707,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     val bytes = Files.readAllBytes(snapshotFile)
     val generatedSnapshot = new String(bytes, StandardCharsets.US_ASCII)
     trim(generatedSnapshot) should be(trim(expected))
-    bytes
+    (snapshotFile.getFileName.toString, bytes)
   }
 
   private def verifyExpectedDelta(sessionId: String, serial: Long)(expected: String) = {
@@ -718,7 +718,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     val bytes = Files.readAllBytes(deltaFile)
     val generatedDelta = new String(bytes, StandardCharsets.US_ASCII)
     trim(generatedDelta) should be(trim(expected))
-    bytes
+    (deltaFile.getFileName.toString, bytes)
   }
 
   def sessionSerialDir(sessionId: String, serial: Long) =
@@ -739,11 +739,22 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     bytes
   }
 
-  private def verifySnapshotDoesntExist(sessionId: String, serial: Long) =
-    rrdpRootDfir.resolve(sessionId).resolve(serial.toString).resolve("snapshot.xml").toFile.exists() should be(false)
+  private def verifySnapshotDoesntExist(sessionId: String, serial: Long) = {
+    val snapshotFound = Files.list(sessionSerialDir(sessionId, serial)).
+      filter(f => Rrdp.isSnapshot(f.getFileName.toString)).
+      findFirst().
+      isPresent
 
-  private def verifyDeltaDoesntExist(sessionId: String, serial: Long) =
-    rrdpRootDfir.resolve(sessionId).resolve(serial.toString).resolve("delta.xml").toFile.exists() should be(false)
+    snapshotFound should be(false)
+  }
 
+  private def verifyDeltaDoesntExist(sessionId: String, serial: Long) = {
+    val deltaFound = Files.list(sessionSerialDir(sessionId, serial)).
+      filter(f => Rrdp.isDelta(f.getFileName.toString)).
+      findFirst().
+      isPresent
+
+    deltaFound should be(false)
+  }
 
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -703,7 +703,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     val snapshotFile = Files.list(sessionSerialDir(sessionId, serial)).
       filter(f => Rrdp.isSnapshot(f.getFileName.toString)).
       findFirst().
-      orElseThrow()
+      get()
     val bytes = Files.readAllBytes(snapshotFile)
     val generatedSnapshot = new String(bytes, StandardCharsets.US_ASCII)
     trim(generatedSnapshot) should be(trim(expected))
@@ -714,7 +714,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     val deltaFile = Files.list(sessionSerialDir(sessionId, serial)).
       filter(f => Rrdp.isDelta(f.getFileName.toString)).
       findFirst().
-      orElseThrow()
+      get()
     val bytes = Files.readAllBytes(deltaFile)
     val generatedDelta = new String(bytes, StandardCharsets.US_ASCII)
     trim(generatedDelta) should be(trim(expected))

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -701,7 +701,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
   private def verifyExpectedSnapshot(sessionId: String, serial: Long)(expected: String) = {
     val snapshotFile = Files.list(sessionSerialDir(sessionId, serial)).
-      filter(f => Rrdp.isSnapshot(f.getFileName.toString)).
+      filter(Rrdp.isSnapshot).
       findFirst().
       get()
     val bytes = Files.readAllBytes(snapshotFile)
@@ -712,7 +712,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
   private def verifyExpectedDelta(sessionId: String, serial: Long)(expected: String) = {
     val deltaFile = Files.list(sessionSerialDir(sessionId, serial)).
-      filter(f => Rrdp.isDelta(f.getFileName.toString)).
+      filter(Rrdp.isDelta).
       findFirst().
       get()
     val bytes = Files.readAllBytes(deltaFile)
@@ -729,7 +729,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
       pgStore.getCurrentSessionInfo
     }
     version.isDefined should be(true)
-    version.get
+    val (session, serial, _, _) = version.get
+    (session, serial)
   }
 
   private def verifyExpectedNotification(expected: String) = {
@@ -740,21 +741,27 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
   }
 
   private def verifySnapshotDoesntExist(sessionId: String, serial: Long) = {
-    val snapshotFound = Files.list(sessionSerialDir(sessionId, serial)).
-      filter(f => Rrdp.isSnapshot(f.getFileName.toString)).
-      findFirst().
-      isPresent
+    val path = sessionSerialDir(sessionId, serial)
+    if (path.toFile.exists()) {
+      val snapshotFound = Files.list(path).
+        filter(Rrdp.isSnapshot).
+        findFirst().
+        isPresent
 
-    snapshotFound should be(false)
+      snapshotFound should be(false)
+    }
   }
 
   private def verifyDeltaDoesntExist(sessionId: String, serial: Long) = {
-    val deltaFound = Files.list(sessionSerialDir(sessionId, serial)).
-      filter(f => Rrdp.isDelta(f.getFileName.toString)).
-      findFirst().
-      isPresent
+    val path = sessionSerialDir(sessionId, serial)
+    if (path.toFile.exists()) {
+      val deltaFound = Files.list(path).
+        filter(Rrdp.isDelta).
+        findFirst().
+        isPresent
 
-    deltaFound should be(false)
+      deltaFound should be(false)
+    }
   }
 
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -69,7 +69,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
           </notification>"""
     }
   }
@@ -90,7 +90,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
       verifyExpectedNotification {
         s"""<notification version="1" session_id="$sessionId" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/$sessionId/$serial/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/$sessionId/$serial/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
           </notification>"""
       }
     }
@@ -148,7 +148,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
           </notification>"""
     }
   }
@@ -195,8 +195,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName2" hash="${hash(Bytes(deltaBytes2)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName2" hash="${hashOf(deltaBytes2).toHex}"/>
           </notification>"""
     }
   }
@@ -261,9 +261,9 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName3" hash="${hash(Bytes(deltaBytes3)).hash}"/>
-            <delta serial="${serial-1}" uri="http://localhost:7788/${sessionId}/${serial-1}/$deltaName2" hash="${hash(Bytes(deltaBytes2)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName3" hash="${hashOf(deltaBytes3).toHex}"/>
+            <delta serial="${serial-1}" uri="http://localhost:7788/${sessionId}/${serial-1}/$deltaName2" hash="${hashOf(deltaBytes2).toHex}"/>
           </notification>"""
     }
   }
@@ -304,8 +304,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hash(Bytes(deltaBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hashOf(deltaBytes).toHex}"/>
           </notification>"""
     }
   }
@@ -360,8 +360,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hash(Bytes(deltaBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hashOf(deltaBytes).toHex}"/>
           </notification>"""
     }
   }
@@ -429,9 +429,9 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName3" hash="${hash(Bytes(deltaBytes3)).hash}"/>
-            <delta serial="${serial - 1}" uri="http://localhost:7788/${sessionId}/${serial - 1}/$deltaName2" hash="${hash(Bytes(deltaBytes2)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName3" hash="${hashOf(deltaBytes3).toHex}"/>
+            <delta serial="${serial - 1}" uri="http://localhost:7788/${sessionId}/${serial - 1}/$deltaName2" hash="${hashOf(deltaBytes2).toHex}"/>
           </notification>"""
     }
   }
@@ -455,13 +455,13 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     Bytes(Files.readAllBytes(rsyncRootDir1.resolve("online").resolve("path1.roa"))) should be(bytes1)
 
-    pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = Some(hash(bytes1).hash), bytes2))), clientId)
+    pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = Some(hashOf(bytes1)), bytes2))), clientId)
     flusher.updateFS()
     waitForRrdpCleanup()
 
     Bytes(Files.readAllBytes(rsyncRootDir1.resolve("online").resolve("path1.roa"))) should be(bytes2)
 
-    pgStore.applyChanges(QueryMessage(Seq(WithdrawQ(uri1, tag = None, hash = hash(bytes2).hash))), clientId)
+    pgStore.applyChanges(QueryMessage(Seq(WithdrawQ(uri1, tag = None, hash = hashOf(bytes2)))), clientId)
     flusher.updateFS()
     waitForRrdpCleanup()
 
@@ -481,13 +481,13 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedDelta(sessionId, serial) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-          <withdraw uri="${uri1}" hash="${hash(bytes2).hash}"/>
+          <withdraw uri="${uri1}" hash="${hashOf(bytes2).toHex}"/>
       </delta>"""
     }
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
           </notification>"""
     }
   }
@@ -523,8 +523,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
       verifyExpectedNotification {
         s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
-            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hash(Bytes(deltaBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
+            <delta serial="${serial}" uri="http://localhost:7788/${sessionId}/${serial}/$deltaName" hash="${hashOf(deltaBytes).toHex}"/>
           </notification>"""
       }
     }
@@ -569,13 +569,13 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     rsyncRootDir1.resolve("online").resolve("path1.roa").toFile.exists() should be(false)
 
-    pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = Some(hash(bytes1).hash), bytes2))), clientId)
+    pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = Some(hashOf(bytes1)), bytes2))), clientId)
     flusher.updateFS()
     waitForRrdpCleanup()
 
     rsyncRootDir1.resolve("online").resolve("path1.roa").toFile.exists() should be(false)
 
-    pgStore.applyChanges(QueryMessage(Seq(WithdrawQ(uri1, tag = None, hash = hash(bytes2).hash))), clientId)
+    pgStore.applyChanges(QueryMessage(Seq(WithdrawQ(uri1, tag = None, hash = hashOf(bytes2)))), clientId)
     flusher.updateFS()
     waitForRrdpCleanup()
 
@@ -595,13 +595,13 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedDelta(sessionId, serial) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <withdraw uri="${uri1}" hash="${hash(bytes2).hash}"/>
+            <withdraw uri="${uri1}" hash="${hashOf(bytes2).toHex}"/>
         </delta>"""
     }
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
           </notification>"""
     }
   }
@@ -624,7 +624,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     Bytes(Files.readAllBytes(rsyncRootDir1.resolve("online").resolve("path1.roa"))) should be(bytes1)
 
-    pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = Some(hash(bytes1).hash), bytes2))), clientId)
+    pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = Some(hashOf(bytes1)), bytes2))), clientId)
     flusher.updateFS()
     waitForRrdpCleanup()
 
@@ -658,7 +658,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     flusher.updateFS()
     waitForRrdpCleanup()
 
-    pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = Some(hash(bytes1).hash), bytes2))), clientId)
+    pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = Some(hashOf(bytes1)), bytes2))), clientId)
 
     // Freeze version but do not do updateFS, as if some
     // other instance has frozen the version.
@@ -666,7 +666,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
       pgStore.freezeVersion
     }
 
-    pgStore.applyChanges(QueryMessage(Seq(WithdrawQ(uri1, tag = None, hash = hash(bytes2).hash))), clientId)
+    pgStore.applyChanges(QueryMessage(Seq(WithdrawQ(uri1, tag = None, hash = hashOf(bytes2)))), clientId)
 
     // this one should catch up and generate two deltas and modify two objects to the rsync repo
     flusher.updateFS()
@@ -688,13 +688,13 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
     verifyExpectedDelta(sessionId, serial) {
       s"""<delta version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <withdraw uri="${uri1}" hash="${hash(bytes2).hash}"/>
+            <withdraw uri="${uri1}" hash="${hashOf(bytes2).toHex}"/>
         </delta>"""
     }
 
     verifyExpectedNotification {
       s"""<notification version="1" session_id="${sessionId}" serial="${serial}" xmlns="http://www.ripe.net/rpki/rrdp">
-            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hash(Bytes(snapshotBytes)).hash}"/>
+            <snapshot uri="http://localhost:7788/${sessionId}/${serial}/$snapshotName" hash="${hashOf(snapshotBytes).toHex}"/>
           </notification>"""
     }
   }

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStreamTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStreamTest.scala
@@ -23,7 +23,7 @@ class HashingSizedStreamTest extends PublicationServerBaseTest with Hashing {
 
     val bytes = (s1 + s2 + s3).getBytes(StandardCharsets.US_ASCII)
     val realBytes = Bytes(bytes)
-    streamHash should be(hash(realBytes))
+    streamHash should be(hashOf(realBytes))
 
     size should be(bytes.length)
   }

--- a/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
@@ -4,7 +4,7 @@ import java.net.URI
 
 import net.ripe.rpki.publicationserver._
 import net.ripe.rpki.publicationserver.model._
-import net.ripe.rpki.publicationserver.store.postresql.RollbackException
+import net.ripe.rpki.publicationserver.store.postgresql.RollbackException
 
 class PgStoreTest extends PublicationServerBaseTest with Hashing {
 


### PR DESCRIPTION
Make delta and snapshot file names unpredictable, i.e.
`snapshot-nnnn.xml` and `delta-nnnn.xml`.