### PR TITLE
Fix freeze version race condition

### DIFF
--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -17,33 +17,12 @@ CREATE UNIQUE INDEX idx_objects_url ON objects (url) WHERE deleted_at IS NULL;
 CREATE UNIQUE INDEX idx_objects_hash ON objects (hash);
 CREATE INDEX idx_objects_client_id ON objects (client_id);
 
-CREATE TABLE object_log
-(
-    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    operation     TEXT   NOT NULL,
-    new_object_id BIGINT,
-    old_object_id BIGINT,
-    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    CHECK (CASE operation
-           WHEN 'INS' THEN old_object_id IS NULL AND new_object_id IS NOT NULL
-           WHEN 'UPD' THEN new_object_id IS NOT NULL AND new_object_id IS NOT NULL
-           WHEN 'DEL' THEN old_object_id IS NOT NULL AND new_object_id IS NULL
-           ELSE FALSE
-           END
-        ),
-    FOREIGN KEY (new_object_id) REFERENCES objects (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
-    FOREIGN KEY (old_object_id) REFERENCES objects (id) ON DELETE RESTRICT ON UPDATE RESTRICT
-);
-
-CREATE INDEX idx_object_log_new_object_id ON object_log (new_object_id) WHERE new_object_id IS NOT NULL;
-CREATE INDEX idx_object_log_old_object_id ON object_log (old_object_id) WHERE old_object_id IS NOT NULL;
 
 CREATE TABLE versions
 (
     id                 BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     session_id         TEXT                     NOT NULL,
     serial             BIGINT                   NOT NULL,
-    last_log_entry_id  BIGINT                   NOT NULL,
     snapshot_file_name TEXT,
     delta_file_name    TEXT,
     snapshot_hash      TEXT CHECK (snapshot_hash ~ '^[0-9a-f]{64}$'),
@@ -72,5 +51,29 @@ CREATE TABLE versions
         )
 );
 
-
 CREATE UNIQUE INDEX idx_versions_session_id_serial ON versions (session_id, serial);
+
+
+CREATE TABLE object_log
+(
+    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    operation     TEXT   NOT NULL,
+    new_object_id BIGINT,
+    old_object_id BIGINT,
+    version_id    BIGINT,
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CHECK (CASE operation
+           WHEN 'INS' THEN old_object_id IS NULL AND new_object_id IS NOT NULL
+           WHEN 'UPD' THEN new_object_id IS NOT NULL AND new_object_id IS NOT NULL
+           WHEN 'DEL' THEN old_object_id IS NOT NULL AND new_object_id IS NULL
+           ELSE FALSE
+           END
+        ),
+    FOREIGN KEY (new_object_id) REFERENCES objects (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    FOREIGN KEY (old_object_id) REFERENCES objects (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    FOREIGN KEY (version_id) REFERENCES versions (id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+CREATE INDEX idx_object_log_new_object_id ON object_log (new_object_id) WHERE new_object_id IS NOT NULL;
+CREATE INDEX idx_object_log_old_object_id ON object_log (old_object_id) WHERE old_object_id IS NOT NULL;
+CREATE INDEX idx_object_log_version_id ON object_log (version_id);

--- a/src/main/scala/net/ripe/rpki/publicationserver/Boot.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Boot.scala
@@ -10,7 +10,7 @@ import akka.util.Timeout
 import com.softwaremill.macwire._
 import io.prometheus.client._
 import net.ripe.rpki.publicationserver.metrics._
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import net.ripe.rpki.publicationserver.util.SSLHelper
 import org.slf4j.Logger
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
@@ -2,7 +2,7 @@ package net.ripe.rpki.publicationserver
 
 import java.net.InetAddress
 
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import spray.json._
 
 import scala.util.Try

--- a/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/PublicationService.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import net.ripe.rpki.publicationserver.metrics.Metrics
 import net.ripe.rpki.publicationserver.model._
 import net.ripe.rpki.publicationserver.parsing.PublicationMessageParser
-import net.ripe.rpki.publicationserver.store.postresql.{PgStore, RollbackException}
+import net.ripe.rpki.publicationserver.store.postgresql.{PgStore, RollbackException}
 
 import java.io.ByteArrayInputStream
 import java.net.URI

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -5,7 +5,7 @@ import net.ripe.rpki.publicationserver.Binaries.Bytes
 import net.ripe.rpki.publicationserver._
 import net.ripe.rpki.publicationserver.fs.{Rrdp, RrdpRepositoryWriter, RsyncRepositoryWriter}
 import net.ripe.rpki.publicationserver.model.INITIAL_SERIAL
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import net.ripe.rpki.publicationserver.util.Time
 import scalikejdbc.DBSession
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
@@ -1,4 +1,4 @@
-package net.ripe.rpki.publicationserver.store.postresql
+package net.ripe.rpki.publicationserver.store.postgresql
 
 import net.ripe.rpki.publicationserver.Binaries.Bytes
 import net.ripe.rpki.publicationserver._

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
@@ -161,6 +161,10 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
       }
     }
 
+    if (changeSet.pdus.isEmpty) {
+      return
+    }
+
     inRepeatableReadTx { implicit session =>
       // Apply all modification while holding a lock on the client ID
       // (which most often is the CA owning the objects)

--- a/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
@@ -1,6 +1,6 @@
 package net.ripe.rpki.publicationserver
 
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import org.mockito.Mockito._
 import spray.json._
 

--- a/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
@@ -12,7 +12,7 @@ import io.prometheus.client.CollectorRegistry
 import net.ripe.rpki.publicationserver.Binaries.Bytes
 import net.ripe.rpki.publicationserver.metrics.Metrics
 import net.ripe.rpki.publicationserver.model._
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import org.scalatest.BeforeAndAfter
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/net/ripe/rpki/publicationserver/integration/PublicationIntegrationTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/integration/PublicationIntegrationTest.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.nio.file._
 
 import net.ripe.rpki.publicationserver.Binaries.Base64
-import net.ripe.rpki.publicationserver.store.postresql.PgStore
+import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import net.ripe.rpki.publicationserver.util.SSLHelper
 import net.ripe.rpki.publicationserver._
 import org.slf4j.LoggerFactory

--- a/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
@@ -4,7 +4,7 @@ import java.net.URI
 
 import net.ripe.rpki.publicationserver._
 import net.ripe.rpki.publicationserver.model._
-import net.ripe.rpki.publicationserver.store.postresql.RollbackException
+import net.ripe.rpki.publicationserver.store.postgresql.RollbackException
 
 class PgStoreTest extends PublicationServerBaseTest with Hashing {
 


### PR DESCRIPTION
Previously it was possible that an in-progress transaction would be
missing from a delta due to the non-transactional nature of sequence
number generation.

The main problem is that `object_log.id` may not be strictly
sequential, but we depend on this when querying a specific
version (since we only store the highest `object_log.id` per version).

Scenario:

- Client 1 starts publishing a million objects (getting ids 1
  ... 499_999, 500_001 ... 1_000_001)

- Client 2 publishes one object (getting id 500_000) and commits.

- Freeze version is called, creating a version with highest id
  500_000. The delta only contains the object from client 2, since
  client 1 has not committed yet.

- Client 1 commits, making objects 1 ... 499_999, 500_001
  ... 1_000_001 visible.

- Freeze version is called, creating a version with highest id
  1_000_001. The delta contains objects 500_001 to 1_000_001, missing
  the first 499_999 objects.

To solve this we now explicitly link `object_log` entries to the
version record ensuring even entries with lower `id` than
`last_log_entry_id` are part of the new delta.