### PR TITLE
Minimize deltas by combining object log entries

### DIFF
--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -30,7 +30,8 @@ $$
     INSERT INTO objects (url, hash, content, client_id)
          VALUES (url_, hash_, bytes_, client_id_)
     ON CONFLICT (url, hash) DO UPDATE
-            SET deleted_at = NULL
+            SET deleted_at = NULL,
+                client_id = EXCLUDED.client_id
       RETURNING *;
 $$ LANGUAGE SQL;
 

--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -254,14 +254,14 @@ CREATE OR REPLACE VIEW latest_version AS
 CREATE OR REPLACE VIEW reasonable_deltas AS
 SELECT z.*
 FROM (SELECT v.*,
-             SUM(delta_size) OVER (PARTITION BY session_id ORDER BY id DESC) AS total_delta_size
+             CAST(SUM(delta_size) OVER (PARTITION BY session_id ORDER BY serial DESC) AS BIGINT) AS total_delta_size
       FROM versions v
      ) AS z,
      latest_version
 WHERE z.session_id = latest_version.session_id
 AND total_delta_size <= latest_version.snapshot_size
 AND z.delta_hash IS NOT NULL
-ORDER BY z.id DESC;
+ORDER BY z.serial DESC;
 
 
 -- Create another entry in the versions table, either the

--- a/src/main/resources/db/migration/R__functions.sql
+++ b/src/main/resources/db/migration/R__functions.sql
@@ -113,7 +113,7 @@ BEGIN
 
     WITH deleted_object AS (
         UPDATE objects SET deleted_at = NOW()
-        WHERE hash = hash_to_replace
+        WHERE url = url_ AND hash = hash_to_replace AND client_id = client_id_
         RETURNING id
     ),
      merged_object AS (
@@ -169,7 +169,7 @@ BEGIN
 
     WITH deleted_object AS (
         UPDATE objects SET deleted_at = NOW()
-        WHERE hash = hash_to_delete
+        WHERE url = url_ AND hash = hash_to_delete AND client_id = client_id_
         RETURNING id
     )
     INSERT INTO object_log(operation, old_object_id)

--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -14,7 +14,6 @@ CREATE TABLE objects
 );
 
 CREATE UNIQUE INDEX idx_objects_url ON objects (url) WHERE deleted_at IS NULL;
-CREATE UNIQUE INDEX idx_objects_url_hash ON objects (url, hash);
 CREATE INDEX idx_objects_client_id ON objects (client_id);
 
 

--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -14,7 +14,7 @@ CREATE TABLE objects
 );
 
 CREATE UNIQUE INDEX idx_objects_url ON objects (url) WHERE deleted_at IS NULL;
-CREATE UNIQUE INDEX idx_objects_hash ON objects (hash);
+CREATE UNIQUE INDEX idx_objects_url_hash ON objects (url, hash);
 CREATE INDEX idx_objects_client_id ON objects (client_id);
 
 

--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -51,7 +51,7 @@ CREATE TABLE versions
         )
 );
 
-CREATE UNIQUE INDEX idx_versions_session_id_serial ON versions (session_id, serial);
+CREATE UNIQUE INDEX idx_versions_session_id_serial ON versions (session_id ASC, serial DESC);
 
 
 CREATE TABLE object_log

--- a/src/main/resources/db/migration/V1__tables.sql
+++ b/src/main/resources/db/migration/V1__tables.sql
@@ -74,6 +74,6 @@ CREATE TABLE object_log
     FOREIGN KEY (version_id) REFERENCES versions (id) ON DELETE CASCADE ON UPDATE RESTRICT
 );
 
-CREATE INDEX idx_object_log_new_object_id ON object_log (new_object_id) WHERE new_object_id IS NOT NULL;
-CREATE INDEX idx_object_log_old_object_id ON object_log (old_object_id) WHERE old_object_id IS NOT NULL;
+CREATE INDEX idx_object_log_new_object_id ON object_log (new_object_id);
+CREATE INDEX idx_object_log_old_object_id ON object_log (old_object_id);
 CREATE INDEX idx_object_log_version_id ON object_log (version_id);

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -4,13 +4,13 @@ import java.net.URI
 import java.nio.file.{Path, Paths}
 import java.util.Map.Entry
 import java.util.concurrent.TimeUnit
-
 import akka.http.scaladsl.settings.ServerSettings
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject, ConfigValue}
+import net.ripe.rpki.publicationserver.store.postgresql.{DeltaInfo, SnapshotInfo}
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.jdk.CollectionConverters.CollectionHasAsScala
-import scala.util.{Failure, Try, Success}
+import scala.util.{Failure, Success, Try}
 
 /**
  * Helper class which can be wired into clients while making sure that the config file is loaded only once.
@@ -56,11 +56,11 @@ class AppConfig {
                         getConfig.getString("postgresql.password")
                     )      
 
-  def snapshotUrl(sessionId: String, serial: Long, snapshotFileName: String) =
-    s"$rrdpRepositoryUri/$sessionId/$serial/$snapshotFileName"
+  def snapshotUrl(snapshotInfo: SnapshotInfo) =
+    s"$rrdpRepositoryUri/${snapshotInfo.sessionId}/${snapshotInfo.serial}/${snapshotInfo.name}"
 
-  def deltaUrl(sessionId: String, serial: Long, deltaFileName: String) =
-    s"$rrdpRepositoryUri/$sessionId/$serial/$deltaFileName"
+  def deltaUrl(deltaInfo: DeltaInfo) =
+    s"$rrdpRepositoryUri/${deltaInfo.sessionId}/${deltaInfo.serial}/${deltaInfo.name}"
 
   lazy val writeRsync = isMode("rsync")
   lazy val writeRrdp = isMode("rrdp")

--- a/src/main/scala/net/ripe/rpki/publicationserver/Binaries.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Binaries.scala
@@ -18,6 +18,8 @@ object Binaries {
     }
 
     override def hashCode(): Int = Arrays.hashCode(value)
+
+    override def toString: String = s"${this.productPrefix}(${Hashing.bytesToHex(value)})"
   }
 
   object Bytes {

--- a/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStore.scala
@@ -11,6 +11,8 @@ import scalikejdbc._
 
 import java.net.URI
 
+case class SnapshotInfo(sessionId: String, serial: Long, name: String, hash: Hash, size: Long)
+case class DeltaInfo(sessionId: String, serial: Long, name: String, hash: Hash, size: Long)
 
 case class RollbackException(val error: BaseError) extends Exception
 
@@ -82,62 +84,61 @@ class PgStore(val pgConfig: PgConfig) extends Hashing with Logging {
       }
   }
 
-  case class SnapshotInfo(name: String, hash: Hash, size: Long)
-  case class DeltaInfo(name: String, hash: Hash, size: Long)
-
   def getCurrentSessionInfo(implicit session: DBSession) = {
 
-    def toSnapshotInfo(name: Option[String], hash: Option[Array[Byte]], size: Option[Long]) =
+    def toSnapshotInfo(sessionId: String, serial: Long, name: Option[String], hash: Option[Array[Byte]], size: Option[Long]) =
       for (n <- name; h <- hash; s <- size)
-        yield SnapshotInfo(n, Hash(h), s)
+        yield SnapshotInfo(sessionId, serial, n, Hash(h), s)
 
-    def toDeltaInfo(name: Option[String], hash: Option[Array[Byte]], size: Option[Long]) =
+    def toDeltaInfo(sessionId: String, serial: Long, name: Option[String], hash: Option[Array[Byte]], size: Option[Long]) =
       for (n <- name; h <- hash; s <- size)
-        yield DeltaInfo(n, Hash(h), s)
+        yield DeltaInfo(sessionId, serial, n, Hash(h), s)
 
     sql"""SELECT session_id, serial,
             snapshot_file_name, snapshot_hash, snapshot_size,
             delta_file_name, delta_hash, delta_size
          FROM latest_version"""
-      .map(rs => (
-        rs.string(1),
-        rs.long(2),
-        toSnapshotInfo(rs.stringOpt(3), rs.bytesOpt(4), rs.longOpt(5)),
-        toDeltaInfo(rs.stringOpt(6), rs.bytesOpt(7), rs.longOpt(8))
-      ))
+      .map(rs => {
+        val sessionId = rs.string(1)
+        val serial = rs.long(2)
+        (
+          sessionId, serial,
+          toSnapshotInfo(sessionId, serial, rs.stringOpt(3), rs.bytesOpt(4), rs.longOpt(5)),
+          toDeltaInfo(sessionId, serial, rs.stringOpt(6), rs.bytesOpt(7), rs.longOpt(8))
+        )
+      })
       .single()
       .apply()
   }
 
   def getReasonableDeltas(sessionId: String)(implicit session: DBSession) = {
-    sql"""SELECT serial, delta_hash, delta_file_name
+    sql"""SELECT session_id, serial, delta_file_name, delta_hash, delta_size
           FROM reasonable_deltas
           WHERE session_id = $sessionId
           ORDER BY serial DESC"""
-      .map { rs =>
-        (rs.long(1),
-          Hash(rs.bytes(2)),
-          rs.string(3))
+      .map { rs => DeltaInfo(rs.string(1), rs.long(2), rs.string(3), Hash(rs.bytes(4)), rs.long(5))
       }
       .list()
       .apply()
   }
 
-  def updateSnapshotInfo(sessionId: String, serial: Long, snapshotFileName: String, hash: Hash, size: Long)(implicit session: DBSession): Unit = {
+  def updateSnapshotInfo(snapshotInfo: SnapshotInfo)(implicit session: DBSession): Unit = {
+    import snapshotInfo._
     sql"""UPDATE versions SET
             snapshot_hash = ${hash.toBytes},
             snapshot_size = $size,
-            snapshot_file_name = $snapshotFileName
+            snapshot_file_name = $name
           WHERE session_id = $sessionId AND serial = $serial"""
       .execute()
       .apply()
   }
 
-  def updateDeltaInfo(sessionId: String, serial: Long, deltaFileName: String, hash: Hash, size: Long)(implicit session: DBSession): Unit = {
+  def updateDeltaInfo(deltaInfo: DeltaInfo)(implicit session: DBSession): Unit = {
+    import deltaInfo._
     sql"""UPDATE versions SET
             delta_hash = ${hash.toBytes},
             delta_size = $size,
-            delta_file_name = $deltaFileName
+            delta_file_name = $name
           WHERE session_id = $sessionId AND serial = $serial"""
       .execute()
       .apply()

--- a/src/test/scala/net/ripe/rpki/publicationserver/integration/PublicationIntegrationTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/integration/PublicationIntegrationTest.scala
@@ -98,7 +98,7 @@ class PublicationIntegrationTest
     val wrongHash = hashOf(Base64(TestBinaries.generateSomeBase64()))
     val w = client.withdraw(clientId, url, wrongHash.toHex)
     w should include(s"""<report_error error_code="no_object_matching_hash">""")
-    w should include(s"""Cannot withdraw the object [${url}], hash does not match, passed ${wrongHash.toHex}, but existing one is $hashStr.""")
+    w should include(s"""Cannot replace or withdraw the object [${url}], hash does not match, passed ${wrongHash.toHex}, but existing one is $hashStr.""")
 
     forMetrics { metrics =>
         metrics should include("""rpkipublicationserver_objects_failure_total{operation="delete",} 1.0""")
@@ -144,7 +144,7 @@ class PublicationIntegrationTest
    val wrongHash = hashOf(Base64(TestBinaries.generateSomeBase64()))
     val response = client.publish(clientId, url, wrongHash.toHex, newBase64)
     response should include(s"""<report_error error_code="no_object_matching_hash">""")
-    response should include(s"""Cannot republish the object [${url}], hash doesn't match, passed ${wrongHash.toHex}, but existing one is $hashStr""")
+    response should include(s"""Cannot replace or withdraw the object [${url}], hash does not match, passed ${wrongHash.toHex}, but existing one is $hashStr""")
 
     forMetrics { metrics =>
         metrics should  include("""rpkipublicationserver_objects_failure_total{operation="replace",} 1.0""")

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -458,8 +458,6 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     flusher.updateFS()
     waitForRrdpCleanup()
 
-    //Bytes(Files.readAllBytes(rsyncRootDir2.resolve("online").resolve("path1.roa"))) should be(bytes2)
-
     val (sessionId, serial) = verifySessionAndSerial
     serial should be(3)
 

--- a/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
@@ -329,8 +329,7 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
   }
 
   test("should allow same object to be published in multiple locations") {
-    val clientId1 = ClientId("client1")
-    val clientId2 = ClientId("client2")
+    val clientId = ClientId("client")
 
     val uri1 = new URI(urlPrefix1 + "/path1")
     val uri2 = new URI(urlPrefix1 + "/path2")
@@ -339,11 +338,11 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
     pgStore.applyChanges(QueryMessage(Seq(
       PublishQ(uri1, tag = None, hash = None, bytes1),
       PublishQ(uri2, tag = None, hash = None, bytes1),
-    )), clientId1)
+    )), clientId)
 
     pgStore.getState should be(Map(
-      uri1 -> (bytes1, hashOf(bytes1), clientId1),
-      uri2 -> (bytes1, hashOf(bytes1), clientId1)
+      uri1 -> (bytes1, hashOf(bytes1), clientId),
+      uri2 -> (bytes1, hashOf(bytes1), clientId)
     ))
 
     pgStore.getLog should be(Seq(
@@ -353,10 +352,10 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
 
     pgStore.applyChanges(QueryMessage(Seq(
       WithdrawQ(uri1, tag = None, hash = hashOf(bytes1))
-    )), clientId1)
+    )), clientId)
 
     pgStore.getState should be(Map(
-      uri2 -> (bytes1, hashOf(bytes1), clientId1)
+      uri2 -> (bytes1, hashOf(bytes1), clientId)
     ))
 
     pgStore.getLog should be(Seq(

--- a/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
@@ -131,7 +131,7 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
     } catch {
       case RollbackException(e) =>
         e.code should be ("permission_failure")
-        e.message should be (s"Not allowed to update an object of another client: [$uri1].")
+        e.message should be (s"Not allowed to replace or withdraw an object of another client: [$uri1].")
     }
 
     pgStore.getState should be(Map(
@@ -189,8 +189,8 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
     } catch {
       case RollbackException(e) =>
         e.code should be ("no_object_matching_hash")
-        e.message should be (s"Cannot republish the object [$uri1], hash doesn't match, " +
-            s"passed ${wrongHash.toHex}, but existing one is ${hashOf(bytes1).toHex}")
+        e.message should be (s"Cannot replace or withdraw the object [$uri1], hash does not match, " +
+            s"passed ${wrongHash.toHex}, but existing one is ${hashOf(bytes1).toHex}.")
     }
 
     pgStore.getState should be(Map(
@@ -257,7 +257,7 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
     } catch {
       case RollbackException(e) =>
           e.code should be ("permission_failure")
-          e.message should be (s"Not allowed to delete an object of another client: [$uri1].")
+          e.message should be (s"Not allowed to replace or withdraw an object of another client: [$uri1].")
     }
 
     pgStore.getState should be(Map(
@@ -315,7 +315,7 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
     } catch {
       case RollbackException(e) =>
         e.code should be ("no_object_matching_hash")
-        e.message should be (s"Cannot withdraw the object [$uri1], hash does not match, " +
+        e.message should be (s"Cannot replace or withdraw the object [$uri1], hash does not match, " +
             s"passed ${wrongHash.toHex}, but existing one is ${hashOf(bytes1).toHex}.")
     }
 


### PR DESCRIPTION
Verifies that RFC8181 clients send us minimal deltas when publishing or withdrawing objects.

Ensures the publication server generates minimal RFC8182 deltas when a new serial is generated. 

Based on the unique hash per URL PR (#47) so includes some changes from there, I will rebase if we decide not to merge that in.