### PR TITLE
Unpredictable, content based file names 

### DIFF
--- a/src/main/resources/db/migration/V2__deterministic-file-names.sql
+++ b/src/main/resources/db/migration/V2__deterministic-file-names.sql
@@ -1,0 +1,7 @@
+ALTER TABLE versions ADD COLUMN file_name_secret BYTEA;
+
+-- "Secret" for existing versions, only used when system is first upgraded or restarted. As these versions disappear
+-- proper randomly secure secrets will be generated.
+UPDATE versions SET file_name_secret = decode(md5(random()::TEXT || clock_timestamp()::TEXT), 'hex');
+
+ALTER TABLE versions ALTER COLUMN file_name_secret SET NOT NULL;

--- a/src/main/scala/net/ripe/rpki/publicationserver/Binaries.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Binaries.scala
@@ -19,6 +19,8 @@ object Binaries {
 
     override def hashCode(): Int = Arrays.hashCode(value)
 
+    def toHex: String = Hashing.bytesToHex(value)
+
     override def toString: String = s"${this.productPrefix}(${Hashing.bytesToHex(value)})"
   }
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/Hashing.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Hashing.scala
@@ -1,8 +1,10 @@
 package net.ripe.rpki.publicationserver
 
-import java.security.MessageDigest
-
 import net.ripe.rpki.publicationserver.Binaries.{Base64, Bytes}
+
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
 case class Hash(private val bytes: Bytes) {
   require(bytes.value.length == 32, s"SHA-256 hash must have length 32, was: ${bytes.value.length}")
@@ -50,5 +52,11 @@ trait Hashing {
 
   def hashOf(b64: Base64): Hash = hashOf(Bytes.fromBase64(b64))
   def hashOf(bytes: Bytes): Hash = hashOf(bytes.value)
+
+  def hmacOf(secret: Bytes, message: Bytes): Bytes = {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(new SecretKeySpec(secret.value, "HmacSHA256"))
+    Bytes(mac.doFinal(message.value))
+  }
 }
 object Hashing extends Hashing

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -116,7 +116,7 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem)
   private def updateRrdpFS(version: VersionInfo, latestFrozenPreviously: Option[Long])(implicit session: DBSession) = {
     import version._
 
-    // Generate snapshot for the latest serial, we are only able to general the latest snapshot
+    // Generate snapshot for the latest serial, we are only able to generate the latest snapshot
     val snapshotInfo = updateSnapshot(version)
     if (!version.isInitialSerial) {
       updateDelta(version)

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
@@ -29,5 +29,8 @@ class HashingSizedStream(secret: Bytes, os: OutputStream) extends FilterOutputSt
     size += len - offset
   }
 
-  def summary = (Hash(digest.digest()), Bytes(mac.doFinal()), size)
+  def summary: (Hash, Bytes, Long) = {
+    close()
+    (Hash(digest.digest()), Bytes(mac.doFinal()), size)
+  }
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
@@ -1,23 +1,24 @@
 package net.ripe.rpki.publicationserver.repository
 
-import java.io.OutputStream
+import java.io.{FilterOutputStream, OutputStream}
 import java.security.MessageDigest
+import net.ripe.rpki.publicationserver.Hash
 
-import net.ripe.rpki.publicationserver.{Hash, Hashing}
-
-class HashingSizedStream(val os: OutputStream) extends Hashing {
+class HashingSizedStream(os: OutputStream) extends FilterOutputStream(os) {
   private var size: Long = 0
   private val digest = MessageDigest.getInstance("SHA-256")
 
-  def write(bytes: Array[Byte]): Unit = {
-    digest.update(bytes)
-    size += bytes.length
-    os.write(bytes)
+  override def write(b: Int): Unit = {
+    out.write(b)
+    digest.update(b.asInstanceOf[Byte])
+    size += 1
+  }
+
+  override def write(bytes: Array[Byte], offset: Int, len: Int): Unit = {
+    out.write(bytes, offset, len)
+    digest.update(bytes, offset, len)
+    size += len - offset
   }
 
   def summary = (Hash(digest.digest()), size)
-
-  def flush() = os.flush()
-
-  def close() = os.close()
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStream.scala
@@ -1,24 +1,33 @@
 package net.ripe.rpki.publicationserver.repository
 
-import java.io.{FilterOutputStream, OutputStream}
-import java.security.MessageDigest
+import net.ripe.rpki.publicationserver.Binaries.Bytes
 import net.ripe.rpki.publicationserver.Hash
 
-class HashingSizedStream(os: OutputStream) extends FilterOutputStream(os) {
+import java.io.{FilterOutputStream, OutputStream}
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+class HashingSizedStream(secret: Bytes, os: OutputStream) extends FilterOutputStream(os) {
   private var size: Long = 0
   private val digest = MessageDigest.getInstance("SHA-256")
+  private val mac = Mac.getInstance("HmacSHA256")
+
+  mac.init(new SecretKeySpec(secret.value, "HmacSHA256"))
 
   override def write(b: Int): Unit = {
     out.write(b)
     digest.update(b.asInstanceOf[Byte])
+    mac.update(b.asInstanceOf[Byte])
     size += 1
   }
 
   override def write(bytes: Array[Byte], offset: Int, len: Int): Unit = {
     out.write(bytes, offset, len)
     digest.update(bytes, offset, len)
+    mac.update(bytes, offset, len)
     size += len - offset
   }
 
-  def summary = (Hash(digest.digest()), size)
+  def summary = (Hash(digest.digest()), Bytes(mac.doFinal()), size)
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/IOStream.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/IOStream.scala
@@ -1,8 +1,9 @@
 package net.ripe.rpki.publicationserver.repository
 
+import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 
 object IOStream {
-  def string(s: String, stream: HashingSizedStream): Unit =
+  def string(s: String, stream: OutputStream): Unit =
     stream.write(s.getBytes(StandardCharsets.US_ASCII))
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -167,7 +167,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
     Bytes(Files.readAllBytes(rsyncRootDir1.resolve("online").resolve("path1.cer"))) should be(bytes1)
 
     pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri2, tag = None, hash = None, bytes2))), clientId)
-    flusher.initFS()
+    flusher.updateFS()
     waitForRrdpCleanup()
 
     Bytes(Files.readAllBytes(rsyncRootDir2.resolve("online").resolve("directory").resolve("path2.cer"))) should be(bytes2)
@@ -268,6 +268,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
 
   test("Should publish, create a session and serial and generate XML files with updateFS") {
     val flusher = newFlusher()
+    flusher.initFS()
+    waitForRrdpCleanup()
 
     val clientId = ClientId("client1")
 
@@ -787,8 +789,8 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
       pgStore.getCurrentSessionInfo
     }
     version.isDefined should be(true)
-    val (session, serial, _, _) = version.get
-    (session, serial)
+    val (versionInfo, _, _) = version.get
+    (versionInfo.sessionId, versionInfo.serial)
   }
 
   private def parseNotification(sessionId: String, serial: Long): (String, SortedMap[Long, String]) = {

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -5,6 +5,7 @@ import net.ripe.rpki.publicationserver._
 import net.ripe.rpki.publicationserver.fs.Rrdp
 import net.ripe.rpki.publicationserver.model._
 
+import java.io.{FileInputStream, InputStreamReader}
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
@@ -794,8 +795,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
   }
 
   private def parseNotification(sessionId: String, serial: Long): (String, SortedMap[Long, String]) = {
-    val notificationContents = Files.readString(rrdpRootDir.resolve("notification.xml"), StandardCharsets.US_ASCII)
-    val notification = XML.loadString(notificationContents)
+    val notification = XML.load(new InputStreamReader(new FileInputStream(rrdpRootDir.resolve("notification.xml").toFile), StandardCharsets.US_ASCII))
     notification \@ "session_id" should be(sessionId)
     notification \@ "serial" should be(serial.toString)
 

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStreamTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/HashingSizedStreamTest.scala
@@ -8,23 +8,26 @@ import net.ripe.rpki.publicationserver.{Hashing, PublicationServerBaseTest}
 
 class HashingSizedStreamTest extends PublicationServerBaseTest with Hashing {
   test("Hashing and size is fine") {
+    val secret = Bytes("the-secret-used-for-this-test".getBytes(StandardCharsets.US_ASCII))
 
     val s1 = "kjbnfdskjvbdjkfbvkjbdfv"
     val s2 = ",mnsdv,mnsdvmnsdv"
     val s3 = "eloihelknfbvln"
 
     val baos = new ByteArrayOutputStream
-    val stream = new HashingSizedStream(baos)
+    val stream = new HashingSizedStream(secret, baos)
     IOStream.string(s1, stream)
     IOStream.string(s2, stream)
     IOStream.string(s3, stream)
 
-    val (streamHash, size) = stream.summary
+    val (streamHash, streamMac, size) = stream.summary
 
     val bytes = (s1 + s2 + s3).getBytes(StandardCharsets.US_ASCII)
-    val realBytes = Bytes(bytes)
-    streamHash should be(hashOf(realBytes))
+    val realBytes = Bytes(baos.toByteArray)
 
+    baos.toByteArray should be(bytes)
+    streamHash should be(hashOf(realBytes))
+    streamMac should be(hmacOf(secret, realBytes))
     size should be(bytes.length)
   }
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/store/postgresql/PgStoreTest.scala
@@ -124,7 +124,7 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
     val (bytes3, _) = TestBinaries.generateObject(10)
 
     pgStore.applyChanges(QueryMessage(Seq(PublishQ(uri1, tag = None, hash = None, bytes1))), clientId)
-    val (_, initialSerial, _) = freezeVersion
+    val VersionInfo(_, initialSerial, _) = freezeVersion
     val initialState = Map(uri1 -> (bytes1, hashOf(bytes1), clientId))
     val initialLog = Seq((uri1, None, Some(bytes1)))
 
@@ -141,7 +141,7 @@ class PgStoreTest extends PublicationServerBaseTest with Hashing {
       WithdrawQ(uri2, tag = None, hash = hashOf(bytes2)),              // Withdraw object not yet published in delta
     )), clientId)
 
-    val (_, unchangedSerial, _) = freezeVersion
+    val VersionInfo(_, unchangedSerial, _) = freezeVersion
     unchangedSerial should be(initialSerial)
     pgStore.getState should be(initialState)
     pgStore.getLog should be(initialLog)


### PR DESCRIPTION
Instead of randomizing the file names they are now based on an HMAC of the generated content. The secret is generated randomly for every RRDP version and stored in the database.

Whenever the file is (re)created the filename is based on the HMAC SHA-256. So on re-creation the files will normally have the same name, unless the contents are now different due to code changes in the publication server.
