### PR TITLE
Raise request timemout and allow it to be set through environment variable

### DIFF
--- a/docker/publication-server-docker.conf
+++ b/docker/publication-server-docker.conf
@@ -27,6 +27,12 @@ locations.rrdp.repository.uri = "https://rrdp.ripe.net"
 locations.rrdp.repository.uri = ${?RRDP_REPOSITORY_URI}
 
 #
+# Allow request timeout to be overridden
+#
+akka.http.server.request-timeout = 60s
+akka.http.server.request-timeout = ${?HTTP_REQUEST_TIMEOUT}
+
+#
 # Configure how the rrdp urls are mapped to the filesystem
 #
 locations.rsync = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -26,8 +26,15 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   jvm-exit-on-fatal-error = on
   http {
-    server.parsing.max-content-length = "256m"
     routing.decode-max-size = "256m"
+    server {
+      parsing.max-content-length = "256m"
+      # docs: It is recommended to use a larger statically configured timeout
+      # (as a “safety net” against programming errors or malicious attackers)
+      # and if needed tighten it using the directives – not the other way
+      # around.
+      request-timeout = 60s
+    }
   }
 }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -20,22 +20,6 @@ publication {
 server.address="::0"
 rrdp.port = 7788
 
-spray.can.host-connector {
-  # The maximum number of parallel connections that an `HttpHostConnector`
-  # is allowed to establish to a host. Must be greater than zero.
-  max-connections = 1024
-
-  # If this setting is enabled, the `HttpHostConnector` pipelines requests
-  # across connections, otherwise only one single request can be "open"
-  # on a particular HTTP connection.
-  pipelining = on
-
-  # The time after which an idle `HttpHostConnector` (without open
-  # connections) will automatically terminate itself.
-  # Set to `infinite` to completely disable idle timeouts.
-  idle-timeout = 30s
-}
-
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "INFO"


### PR DESCRIPTION
Alternative approach: Only raise it for the publication call based on how many objects are received. I think with 20s, setting it during request processing is fine.