### PR TITLE
Build and push docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,39 @@ jobs:
           path: |
             target/scoverage-report/**/*
             target/test-reports/**/*
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: sbt-build-test
+    if: ${{ github.ref == 'refs/heads/pg-store' }}
+
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@v2
+
+      - name: Fetch jar
+        uses: actions/download-artifact@v2
+        with:
+          name: rpki-publication-server-jar
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        id: docker_build_publication_server
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ripencc/rpki-publication-server:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_publication_server.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ripencc/rpki-publication-server:latest
+          labels:
+            - "org.label-schema.vcs-ref=${{ github.sha }}"
 
       - name: Image digest
         run: echo ${{ steps.docker_build_publication_server.outputs.digest }}


### PR DESCRIPTION
Build and push the ripencc/rpki-publication-server:latest image from Github
Actions `pg-store` branch.

Images are pushed to Docker Hub at https://hub.docker.com/r/ripencc/rpki-publication-server.

Note that when `pg-store` finally merges into `main` we have to adjust the image job condition.