### PR TITLE
Readiness endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 RPKI Publication Server
 =======================
 
-This is the RIPE NCC's implementation of [A Publication Protocol for the Resource Public Key Infrastructure] 
-(https://tools.ietf.org/html/draft-weiler-sidr-publication) and [RPKI Repository Delta Protocol]
-(https://tools.ietf.org/wg/sidr/draft-ietf-sidr-delta-protocol/).
+This is the RIPE NCC's implementation of 
+[A Publication Protocol for the Resource Public Key Infrastructure](https://datatracker.ietf.org/doc/html/rfc8181) and 
+[RPKI Repository Delta Protocol](https://datatracker.ietf.org/doc/html/rfc8182).
 
 Building the project
 --------------------

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -78,4 +78,4 @@ default.timeout = 10m
 
 # minimum snapshot size to indicate readiness of server
 minimum.snapshot.size = 100m
-
+minimum.snapshot.objects.count = 1000

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -77,5 +77,5 @@ unpublished-file-retain-period = 60m
 default.timeout = 10m
 
 # minimum snapshot size to indicate readiness of server
-minimum.snapshot.size = 300m
+minimum.snapshot.size = 100m
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ publication {
   # and specify it's filename and password here
   server.truststore.location = ""
   server.truststore.password = ""
-
+ 
   server.repository-write-interval = 120s
 
   # Maximum entity size, only applied to endpoints where needed, preferibly behind client tls
@@ -77,5 +77,4 @@ unpublished-file-retain-period = 60m
 default.timeout = 10m
 
 # minimum snapshot size to indicate readiness of server
-minimum.snapshot.size = 100m
 minimum.snapshot.objects.count = 1000

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -75,3 +75,7 @@ locations.rsync = {
 unpublished-file-retain-period = 60m
 
 default.timeout = 10m
+
+# minimum snapshot size to indicate readiness of server
+minimum.snapshot.size = 300m
+

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -18,7 +18,6 @@ import scala.util.{Failure, Success, Try}
 class AppConfig {
   def getConfig = AppConfig.config
 
-  lazy val minimumSnapshotSize = getConfig.getMemorySize("minimum.snapshot.size").toBytes()
   lazy val minimumSnapshotObjectsCount = getConfig.getInt("minimum.snapshot.objects.count")
   lazy val publicationPort = getConfig.getInt("publication.port")
   lazy val rrdpPort = getConfig.getInt("rrdp.port")

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -19,6 +19,7 @@ class AppConfig {
   def getConfig = AppConfig.config
 
   lazy val minimumSnapshotSize = getConfig.getMemorySize("minimum.snapshot.size").toBytes()
+  lazy val minimumSnapshotObjectsCount = getConfig.getInt("minimum.snapshot.objects.count")
   lazy val publicationPort = getConfig.getInt("publication.port")
   lazy val rrdpPort = getConfig.getInt("rrdp.port")
   lazy val rrdpRepositoryPath = getConfig.getString("locations.rrdp.repository.path")

--- a/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/AppConfig.scala
@@ -18,6 +18,7 @@ import scala.util.{Failure, Success, Try}
 class AppConfig {
   def getConfig = AppConfig.config
 
+  lazy val minimumSnapshotSize = getConfig.getMemorySize("minimum.snapshot.size").toBytes()
   lazy val publicationPort = getConfig.getInt("publication.port")
   lazy val rrdpPort = getConfig.getInt("rrdp.port")
   lazy val rrdpRepositoryPath = getConfig.getString("locations.rrdp.repository.path")

--- a/src/main/scala/net/ripe/rpki/publicationserver/Boot.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/Boot.scala
@@ -53,7 +53,7 @@ class PublicationServerApp(conf: AppConfig, https: HttpsConnectionContext, logge
   var httpsBinding: Future[ServerBinding] = _
   var repositoryWriter: Future[Cancellable] = _
 
-  val healthChecks = new HealthChecks(conf)
+  implicit val healthChecks = new HealthChecks(conf)
 
   def run(): Unit = {
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
@@ -18,19 +18,19 @@ class HealthChecks(val appConfig: AppConfig) {
   case class Health(buildInformation: BuildInformation, databaseConnectivity: String)
   object Health
 
-  case class SnapshotStatus(ready: Boolean, size: Long, objectsCount: Int)
+  case class SnapshotStatus(ready: Boolean, objectsCount: Int)
   object SnapshotStatus
 
   object HealthChecksJsonProtocol extends DefaultJsonProtocol {
     implicit val memoryFormat = jsonFormat3(Memory.apply)
     implicit val buildInformationFormat = jsonFormat4(BuildInformation.apply)
-    implicit val snapshotFormat = jsonFormat3(SnapshotStatus.apply)
+    implicit val snapshotFormat = jsonFormat2(SnapshotStatus.apply)
     implicit val healthFormat = jsonFormat2(Health.apply)
   }
 
   lazy val objectStore = PgStore.get(appConfig.pgConfig)
 
-  var snapshotStatus = SnapshotStatus(false, 0, 0)
+  var snapshotStatus = SnapshotStatus(false, 0)
 
   import HealthChecksJsonProtocol._
 
@@ -63,7 +63,7 @@ class HealthChecks(val appConfig: AppConfig) {
     Memory(free = mb(r.freeMemory), total = mb(r.totalMemory), max = mb(r.maxMemory))
   }
 
-  def updateSnapshot(snapshotSize: Long, objectsCount: Int) = {
-    snapshotStatus = SnapshotStatus(snapshotSize > appConfig.minimumSnapshotSize && objectsCount > appConfig.minimumSnapshotObjectsCount, snapshotSize, objectsCount)
+  def updateSnapshot(objectsCount: Int) = {
+    snapshotStatus = SnapshotStatus(objectsCount > appConfig.minimumSnapshotObjectsCount, objectsCount)
   }
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
@@ -15,16 +15,22 @@ class HealthChecks(val appConfig: AppConfig) {
   case class Memory(free: String, total: String, max: String)
   object Memory
 
-  case class Health(buildInformation: BuildInformation, databaseConnectivity: String)
+  case class Health(buildInformation: BuildInformation, databaseConnectivity: String, snapshotStatus: SnapshotStatus)
   object Health
+
+  case class SnapshotStatus(ready: Boolean, size: Long)
+  object SnapshotStatus
 
   object HealthChecksJsonProtocol extends DefaultJsonProtocol {
     implicit val memoryFormat = jsonFormat3(Memory.apply)
     implicit val buildInformationFormat = jsonFormat4(BuildInformation.apply)
-    implicit val healthFormat = jsonFormat2(Health.apply)
+    implicit val snapshotFormat = jsonFormat2(SnapshotStatus.apply)
+    implicit val healthFormat = jsonFormat3(Health.apply)
   }
 
   lazy val objectStore = PgStore.get(appConfig.pgConfig)
+
+  var snapshotStatus = SnapshotStatus(false, 0)
 
   import HealthChecksJsonProtocol._
 
@@ -35,7 +41,7 @@ class HealthChecks(val appConfig: AppConfig) {
       host = InetAddress.getLocalHost.getHostName,
       memory = memoryStat
     )
-    val health = Health(buildInformation, checkDatabaseStatus)
+    val health = Health(buildInformation, checkDatabaseStatus, snapshotStatus)
 
     health.toJson.prettyPrint
   }
@@ -50,5 +56,9 @@ class HealthChecks(val appConfig: AppConfig) {
   def memoryStat = {
     val r = Runtime.getRuntime
     Memory(free = mb(r.freeMemory), total = mb(r.totalMemory), max = mb(r.maxMemory))
+  }
+
+  def updateSnapshot(snapshotSize: Long) = {
+    snapshotStatus = SnapshotStatus(snapshotSize > appConfig.minimumSnapshotSize, snapshotSize)
   }
 }

--- a/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
@@ -1,7 +1,9 @@
 package net.ripe.rpki.publicationserver
 
-import java.net.InetAddress
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives.complete
 
+import java.net.InetAddress
 import net.ripe.rpki.publicationserver.store.postgresql.PgStore
 import spray.json._
 
@@ -46,9 +48,11 @@ class HealthChecks(val appConfig: AppConfig) {
     health.toJson.prettyPrint
   }
 
-  def readinessString: String = {
-
-    snapshotStatus.toJson.prettyPrint
+  def readinessResponse = {
+    if(snapshotStatus.ready)
+      complete(snapshotStatus.toJson.prettyPrint)
+    else
+      complete(StatusCodes.ServiceUnavailable)
   }
 
   def checkDatabaseStatus: String = {

--- a/src/main/scala/net/ripe/rpki/publicationserver/RRDPService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/RRDPService.scala
@@ -43,7 +43,13 @@ trait RRDPService extends RepositoryPath {
       get {
         complete(healthChecks.healthString)
       }
+    } ~ 
+    path("monitoring" / "readiness") {
+      get {
+        complete(healthChecks.readinessString)
+      }
     }
+
 
   val rrdpAndMonitoringRoutes: Route = rrdpRoutes ~ monitoringRoutes
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/RRDPService.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/RRDPService.scala
@@ -46,7 +46,7 @@ trait RRDPService extends RepositoryPath {
     } ~ 
     path("monitoring" / "readiness") {
       get {
-        complete(healthChecks.readinessString)
+        healthChecks.readinessResponse
       }
     }
 

--- a/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/repository/DataFlusher.scala
@@ -133,7 +133,7 @@ class DataFlusher(conf: AppConfig)(implicit val system: ActorSystem, implicit va
     val (snapshotInfo, objectsCount) = updateSnapshot(version)
 
     // Inform healthcheck for readiness we have updated snapshot
-    healthChecks.updateSnapshot(snapshotInfo.size, objectsCount)
+    healthChecks.updateSnapshot(objectsCount)
 
     if (!version.isInitialSerial) {
       updateDelta(version)

--- a/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
@@ -33,7 +33,19 @@ class HealthChecksTest extends PublicationServerBaseTest {
   }
 
   test("check config parsing default minimum snapshot size in mega binary bytes"){
-    appConfig.minimumSnapshotSize should equal(300*1024*1024L)
+    appConfig.minimumSnapshotSize should equal(100*1024*1024L)
+  }
+
+  test("snapshot status should be ready when we have reasonable sized snapshot"){
+    val healthChecks = new HealthChecks(appConfig)
+    healthChecks.updateSnapshot(101*1024*1024L)
+    healthChecks.snapshotStatus.ready should be (true)
+  }
+
+  test("snapshot status should be ready when we don't yet have reasonable sized snapshot"){
+    val healthChecks = new HealthChecks(appConfig)
+    healthChecks.updateSnapshot(99*1024*1024L)
+    healthChecks.snapshotStatus.ready should be (false)
   }
 
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
@@ -38,13 +38,13 @@ class HealthChecksTest extends PublicationServerBaseTest {
 
   test("snapshot status should be ready when we have reasonable sized snapshot"){
     val healthChecks = new HealthChecks(appConfig)
-    healthChecks.updateSnapshot(101*1024*1024L)
+    healthChecks.updateSnapshot(101*1024*1024L, 1001)
     healthChecks.snapshotStatus.ready should be (true)
   }
 
   test("snapshot status should be ready when we don't yet have reasonable sized snapshot"){
     val healthChecks = new HealthChecks(appConfig)
-    healthChecks.updateSnapshot(99*1024*1024L)
+    healthChecks.updateSnapshot(99*1024*1024L, 999)
     healthChecks.snapshotStatus.ready should be (false)
   }
 

--- a/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
@@ -35,13 +35,13 @@ class HealthChecksTest extends PublicationServerBaseTest {
   test("snapshot status should be ready when we have reasonable sized snapshot"){
     val healthChecks = new HealthChecks(appConfig)
     healthChecks.updateSnapshot(1001)
-    healthChecks.snapshotStatus.ready should be (true)
+    healthChecks.snapshotStatus().ready should be (true)
   }
 
   test("snapshot status should be ready when we don't yet have reasonable sized snapshot"){
     val healthChecks = new HealthChecks(appConfig)
     healthChecks.updateSnapshot(999)
-    healthChecks.snapshotStatus.ready should be (false)
+    healthChecks.snapshotStatus().ready should be (false)
   }
 
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
@@ -31,4 +31,9 @@ class HealthChecksTest extends PublicationServerBaseTest {
     }
     thrown.getMessage should equal("Cannot connect!")
   }
+
+  test("check config parsing default minimum snapshot size in mega binary bytes"){
+    appConfig.minimumSnapshotSize should equal(300*1024*1024L)
+  }
+
 }

--- a/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/HealthChecksTest.scala
@@ -32,19 +32,15 @@ class HealthChecksTest extends PublicationServerBaseTest {
     thrown.getMessage should equal("Cannot connect!")
   }
 
-  test("check config parsing default minimum snapshot size in mega binary bytes"){
-    appConfig.minimumSnapshotSize should equal(100*1024*1024L)
-  }
-
   test("snapshot status should be ready when we have reasonable sized snapshot"){
     val healthChecks = new HealthChecks(appConfig)
-    healthChecks.updateSnapshot(101*1024*1024L, 1001)
+    healthChecks.updateSnapshot(1001)
     healthChecks.snapshotStatus.ready should be (true)
   }
 
   test("snapshot status should be ready when we don't yet have reasonable sized snapshot"){
     val healthChecks = new HealthChecks(appConfig)
-    healthChecks.updateSnapshot(99*1024*1024L, 999)
+    healthChecks.updateSnapshot(999)
     healthChecks.snapshotStatus.ready should be (false)
   }
 

--- a/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/PublicationServerBaseTest.scala
@@ -28,7 +28,9 @@ abstract class PublicationServerBaseTest extends AnyFunSuite with BeforeAndAfter
 
   var tempXodusDir: File = _
 
-  val pgTestConfig = new AppConfig().pgConfig
+  val appConfig = new AppConfig()
+
+  val pgTestConfig = appConfig.pgConfig
 
   protected def createPgStore = {
     PgStore.migrateDB(pgTestConfig)

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherStressTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherStressTest.scala
@@ -29,6 +29,7 @@ class DataFlusherStressTest extends PublicationServerBaseTest with Hashing {
     )
   }
 
+  implicit val healthChecks = new HealthChecks(conf)
   val flusher = new DataFlusher(conf)
 
   before {

--- a/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
+++ b/src/test/scala/net/ripe/rpki/publicationserver/repository/DataFlusherTest.scala
@@ -45,6 +45,7 @@ class DataFlusherTest extends PublicationServerBaseTest with Hashing {
         URI.create(urlPrefix2) -> rsyncRootDir2
       )
     }
+    implicit val healthChecks = new HealthChecks(conf)
     new DataFlusher(conf)
   }
 


### PR DESCRIPTION
Updating snapshot status whenever Data Flusher updates snapshot.  Reusing health check end point with additional snapshot status with a ready field that will be true whenever snapshot size is more than reasonable minimum snapshot-size (configurable).

