### PR TITLE
Prepare for PostgreSQL based 2.0 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,6 @@ javaOptions in run ++= Seq("-Xmx2G")
 
 enablePlugins(JavaServerAppPackaging, UniversalDeployPlugin)
 
-resolvers += "JCenter" at "https://jcenter.bintray.com/"
-
 libraryDependencies ++= {
   val akkaV = "2.6.16"
   val akkaHttp = "10.2.6"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "net.ripe"
 
 name := "rpki-publication-server"
 
-version := "1.1-SNAPSHOT"
+version := "2.0-SNAPSHOT"
 
 scalaVersion := "2.13.6"
 

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,6 @@ libraryDependencies ++= {
     "com.softwaremill.macwire" %% "util"                  % "2.3.3" % "provided",
     "com.softwaremill.macwire" %% "proxy"                 % "2.3.3" % "provided",
     "com.google.guava"         %  "guava"                 % "18.0",
-    "com.google.code.findbugs" %  "jsr305"                % "3.0.2",
     "org.apache.commons"       % "commons-io"             % "1.3.2",
     "io.prometheus"            % "simpleclient"           % "0.9.0",
     "io.prometheus"            % "simpleclient_common"    % "0.9.0",

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := "rpki-publication-server"
 
 version := "1.1-SNAPSHOT"
 
-scalaVersion := "2.13.3"
+scalaVersion := "2.13.6"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= {
   Seq(
     "com.typesafe.akka"        %% "akka-http"             % akkaHttp,
     "com.typesafe.akka"        %% "akka-http-core"        % akkaHttp,
-    "com.typesafe.akka"        %% "akka-http-testkit"     % akkaHttp,
+    "com.typesafe.akka"        %% "akka-http-testkit"     % akkaHttp  % "test",
     "com.typesafe.akka"        %% "akka-http-spray-json"  % akkaHttp,
     "com.typesafe.akka"        %% "akka-stream-testkit"   % akkaV,
     "com.typesafe.akka"        %% "akka-testkit"          % akkaV     % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,6 @@ libraryDependencies ++= {
     "com.softwaremill.macwire" %% "proxy"                 % "2.3.3" % "provided",
     "com.google.guava"         %  "guava"                 % "18.0",
     "com.google.code.findbugs" %  "jsr305"                % "3.0.2",
-    "org.jetbrains.xodus"      % "xodus-entity-store"     % "1.0.5",
     "org.apache.commons"       % "commons-io"             % "1.3.2",
     "io.prometheus"            % "simpleclient"           % "0.9.0",
     "io.prometheus"            % "simpleclient_common"    % "0.9.0",

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,6 @@ libraryDependencies ++= {
     "org.scalatest"            %% "scalatest"             % "3.1.4"   % "test",
     "org.mockito"               % "mockito-all"           % "1.10.19" % "test",
     "com.fasterxml.woodstox"    % "woodstox-core"         % "6.2.4",
-    "com.sun.xml.bind"          % "jaxb1-impl"            % "2.2.5.1",
     "ch.qos.logback"            % "logback-classic"       % "1.2.3",
     "com.softwaremill.macwire" %% "macros"                % "2.3.3" % "provided",
     "com.softwaremill.macwire" %% "macrosakka"            % "2.3.3" % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,6 @@ libraryDependencies ++= {
     "com.typesafe.akka"        %% "akka-http-testkit"     % akkaHttp,
     "com.typesafe.akka"        %% "akka-http-spray-json"  % akkaHttp,
     "com.typesafe.akka"        %% "akka-stream-testkit"   % akkaV,
-    "com.typesafe.akka"        %% "akka-actor"            % akkaV,
     "com.typesafe.akka"        %% "akka-testkit"          % akkaV     % "test",
     "com.typesafe.akka"        %% "akka-slf4j"            % akkaV,
     "org.scalatest"            %% "scalatest"             % "3.2.9"   % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,6 @@ javaOptions in run ++= Seq("-Xmx2G")
 
 enablePlugins(JavaServerAppPackaging, UniversalDeployPlugin)
 
-resolvers += "Codehaus Maven2 Repository" at "https://repository.codehaus.org/"
-
 resolvers += "JCenter" at "https://jcenter.bintray.com/"
 
 libraryDependencies ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,8 @@ resolvers += "Codehaus Maven2 Repository" at "https://repository.codehaus.org/"
 resolvers += "JCenter" at "https://jcenter.bintray.com/"
 
 libraryDependencies ++= {
-  val akkaV = "2.6.14"
-  val akkaHttp = "10.2.4"
+  val akkaV = "2.6.16"
+  val akkaHttp = "10.2.6"
   Seq(
     "com.typesafe.akka"        %% "akka-http"             % akkaHttp,
     "com.typesafe.akka"        %% "akka-http-core"        % akkaHttp,
@@ -45,24 +45,24 @@ libraryDependencies ++= {
     "com.typesafe.akka"        %% "akka-actor"            % akkaV,
     "com.typesafe.akka"        %% "akka-testkit"          % akkaV     % "test",
     "com.typesafe.akka"        %% "akka-slf4j"            % akkaV,
-    "org.scalatest"            %% "scalatest"             % "3.1.4"   % "test",
+    "org.scalatest"            %% "scalatest"             % "3.2.9"   % "test",
     "org.mockito"               % "mockito-all"           % "1.10.19" % "test",
-    "com.fasterxml.woodstox"    % "woodstox-core"         % "6.2.4",
-    "ch.qos.logback"            % "logback-classic"       % "1.2.3",
-    "com.softwaremill.macwire" %% "macros"                % "2.3.3" % "provided",
-    "com.softwaremill.macwire" %% "macrosakka"            % "2.3.3" % "provided",
-    "com.softwaremill.macwire" %% "util"                  % "2.3.3" % "provided",
-    "com.softwaremill.macwire" %% "proxy"                 % "2.3.3" % "provided",
-    "com.google.guava"         %  "guava"                 % "18.0",
-    "org.apache.commons"       % "commons-io"             % "1.3.2",
-    "io.prometheus"            % "simpleclient"           % "0.9.0",
-    "io.prometheus"            % "simpleclient_common"    % "0.9.0",
-    "org.scala-lang.modules"   %% "scala-xml"             % "1.2.0",
+    "com.fasterxml.woodstox"    % "woodstox-core"         % "6.2.6",
+    "ch.qos.logback"            % "logback-classic"       % "1.2.6",
+    "com.softwaremill.macwire" %% "macros"                % "2.4.1" % "provided",
+    "com.softwaremill.macwire" %% "macrosakka"            % "2.4.1" % "provided",
+    "com.softwaremill.macwire" %% "util"                  % "2.4.1" % "provided",
+    "com.softwaremill.macwire" %% "proxy"                 % "2.4.1" % "provided",
+    "com.google.guava"          % "guava"                 % "23.0",
+    "org.apache.commons"        % "commons-io"            % "1.3.2",
+    "io.prometheus"             % "simpleclient"          % "0.12.0",
+    "io.prometheus"             % "simpleclient_common"   % "0.12.0",
+    "org.scala-lang.modules"   %% "scala-xml"             % "2.0.1",
     "org.scalikejdbc"          %% "scalikejdbc"           % "3.5.+",
-    "org.postgresql"           % "postgresql"             % "42.2.15",
-    "org.json4s"               %% "json4s-native"         % "3.7.0-M6",
-    "org.flywaydb"             % "flyway-core"            % "6.5.5",
-    "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"
+    "org.postgresql"            % "postgresql"            % "42.2.23",
+    "org.json4s"               %% "json4s-native"         % "4.0.2",
+    "org.flywaydb"              % "flyway-core"           % "7.14.1",
+    "org.scala-lang.modules"   %% "scala-parallel-collections" % "1.0.3"
   )
 }
 


### PR DESCRIPTION
Updated Scala to 2.13.6.

Updated and cleaned up dependencies.

Removed the old codehaus repository (it no longer exists) and the unneeded JCenter repository (based on clearing the cache and updating the dependencies, didn't get any errors).
