### PR TITLE
Configure minimal number of snapshot objects.

### DIFF
--- a/docker/publication-server-docker.conf
+++ b/docker/publication-server-docker.conf
@@ -51,3 +51,6 @@ postgresql = {
 
 locations.rrdp.repository.path = "/data/rrdp"
 locations.rrdp.repository.path = ${?RRDP_REPOSITORY_PATH}
+
+minimum.snapshot.objects.count = 50000
+minimum.snapshot.objects.count = ${?MINIMUM_SNAPSHOT_OBJECTS}

--- a/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
+++ b/src/main/scala/net/ripe/rpki/publicationserver/HealthChecks.scala
@@ -68,7 +68,7 @@ class HealthChecks(val appConfig: AppConfig) extends Logging {
 
   def snapshotStatus(): SnapshotStatus = {
     val current = snapshotObjectCounts.get()
-    SnapshotStatus(current > appConfig.minimumSnapshotObjectsCount, current)
+    SnapshotStatus(current >= appConfig.minimumSnapshotObjectsCount, current)
   }
 
   def readinessResponse = {


### PR DESCRIPTION
This is to be able to configure readiness for k8s deployment and be able to run it without objects.