### PR TITLE
Track the sbt dependency graph in dependabot

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,18 @@
+name: Update Dependency Graph
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  update-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2
+        with:
+          working-directory: './'
+
+permissions:
+  contents: write


### PR DESCRIPTION
This submits the sbt dependency graph to the dependency submission api, enabling the dependency graph in Github.