### PR TITLE
Push `latest` and version tags from release builds only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     needs: sbt-build
     with:
       jar-artifact: ${{ needs.sbt-build.outputs.jar-artifact }}
-      tag: latest
+      tags: ripencc/rpki-publication-server:unstable
       push: ${{ github.ref == 'refs/heads/main' }}
     secrets:
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,8 +11,8 @@ on:
         type: boolean
         required: true
         default: false
-      tag:
-        description: "Image tag"
+      tags:
+        description: "Image tags (comma separated) to build and push"
         type: string
         required: true
     secrets:
@@ -51,7 +51,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: ${{ inputs.push }}
-          tags: ripencc/rpki-publication-server:${{ inputs.tag }}
+          tags: ${{ inputs.tags }}
           labels: "org.label-schema.vcs-ref=${{ github.sha }}"
           build-args: |
             PUBLICATION_SERVER_JAR=./rpki-publication-server.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       jar-artifact: ${{ needs.sbt-build.outputs.jar-artifact }}
       push: true
-      tag: ${{ github.event.release.tag_name }}
+      tags: ripencc/rpki-publication-server:${{ github.event.release.tag_name }}, ripencc/rpki-publication-server:latest
     secrets:
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_hub_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
Change the CI build of branch `main` to push an `unstable` image so that `latest` is preserved for release builds.